### PR TITLE
fix: remove dependency on placeholder `fs` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "devDependencies": {
-    "fs": "0.0.1-security",
     "jscs": "^3.0.7",
     "semantic-release": "^6.3.6",
     "tap": "^10.3.2",


### PR DESCRIPTION
Its unused, and it conflicts with real `fs` package for a customer