### PR TITLE
fix: improve ver detection logic in dep tree, support diff len of attr

### DIFF
--- a/lib/parse-mvn.js
+++ b/lib/parse-mvn.js
@@ -77,9 +77,11 @@ function assemblePackage(source, projectDeps, parent, withDev) {
 
 function createPackage(pkgStr, parent) {
   var range = getConstraint(pkgStr);
+
   if (range) {
     pkgStr = pkgStr.substring(0, pkgStr.indexOf(' '));
   }
+
   var parts = pkgStr.split(':');
   var result = {
     groupId: parts[0],
@@ -89,18 +91,25 @@ function createPackage(pkgStr, parent) {
     name: parts[0] + ':' + parts[1],
     dependencies: {},
   };
-  var selfPkg = parts[0] + ':' + parts[1] + '@' + parts[3];
-  result.from = parent ?
-    parent.from.concat(selfPkg) :
-    [selfPkg];
-  if (parts.length === 5) {
-    result.scope = parts[4];
+
+  if (parts.length >= 5) {
+    result.scope = parts[parts.length - 1];
+    result.version = parts[parts.length - 2];
   }
+
   if (range) {
     result.dep = range;
   }
+
+  var selfPkg = result.groupId + ':' + result.artifactId + '@' + result.version;
+
+  result.from = parent ?
+    parent.from.concat(selfPkg) :
+    [selfPkg];
+
   return result;
 }
+
 
 function dequote(str) {
   return str.slice(str.indexOf('"') + 1, str.lastIndexOf('"'));

--- a/test/fixtures/maven-dependency-tree-with-type.txt
+++ b/test/fixtures/maven-dependency-tree-with-type.txt
@@ -1,0 +1,18 @@
+[INFO] Scanning for projects...
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] Building Spring Boot Quartz Starter 2.0.0.BUILD-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO]
+[INFO] --- maven-dependency-plugin:2.10:tree (default-cli) @ spring-boot-starter-quartz ---
+[INFO] digraph "com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" {
+[INFO]  "com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" -> "com.snyk.tester:tester-queue:jar:15.0.0:compile" ;
+[INFO]  "com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" -> "com.snyk.tester:tester-queue:test-jar:tests:15.0.0:test" ;
+[INFO]  }
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 1.956 s
+[INFO] Finished at: 2017-06-19T14:28:14+03:00
+[INFO] Final Memory: 23M/331M
+[INFO] ------------------------------------------------------------------------

--- a/test/functional/parse-mvn.test.js
+++ b/test/functional/parse-mvn.test.js
@@ -32,3 +32,14 @@ test('test with bad mvn dependency:tree output', function (t) {
   var data = parse(mavenOutput, true);
   t.equal(data.ok, false, 'bad output detected');
 });
+
+test('test with type "test-jar" in mvn dependency', function (t) {
+  t.plan(1);
+  var mavenOutput = fs.readFileSync(path.join(
+    __dirname, '..', 'fixtures',
+    'maven-dependency-tree-with-type.txt'), 'utf8');
+  var result = parse(mavenOutput, true);
+
+  t.equal(result.data.dependencies['com.snyk.tester:tester-queue'].version,
+          '15.0.0');
+});


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

when setting the type attribute in the dependency it adds another column in the dependency tree which broke our version detection