### PR TITLE
fix: throw on parsing errors, as expected by the cli

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,21 +15,11 @@ function inspect(root, targetFile, options) {
   if (!options) {
     options = {dev: false};
   }
-  return subProcess.execute(
-    'mvn',
-    buildArgs(root, targetFile, options.args),
-    {cwd: root}
-  )
+  var mvnArgs = buildArgs(root, targetFile, options.args);
+  return subProcess.execute('mvn', mvnArgs, {cwd: root})
     .then(function (result) {
-      var parseResult = {};
       try {
-        parseResult = parse(result, options.dev);
-      } catch (error) {
-        console.log('\nAn unknown error occurred. ' +
-      'Please include the trace below when reporting to Snyk:', error, '\n');
-        return Promise.reject('');
-      }
-      if (parseResult.ok) {
+        var parseResult = parse(result, options.dev);
         return {
           plugin: {
             name: 'bundled:maven',
@@ -37,9 +27,16 @@ function inspect(root, targetFile, options) {
           },
           package: parseResult.data,
         };
+      } catch (error) {
+        error.message = error.message + '\n\n' +
+          'Please make sure that Apache Maven Dependency Plugin ' +
+          'version 2.2 or above is installed, and that ' +
+          '`mvn ' + mvnArgs.join(' ') + '` executes successfully ' +
+          'on this project.\n\n' +
+          'If the problem persists, collect the output of ' +
+          '`mvn ' + mvnArgs.join(' ') + '` and contact support@snyk.io\n';
+        throw error;
       }
-      return Promise.reject(parseResult.message ||
-      'An internal error has occured. Please contact Snyk for support.');
     });
 }
 

--- a/lib/parse-mvn.js
+++ b/lib/parse-mvn.js
@@ -4,30 +4,28 @@ var packageFormatVersion = 'mvn:0.0.1';
 var newline = /[\r\n]+/g;
 var logLabel = /^\[\w+\]\s*/gm;
 var digraph = /digraph([\s\S]*?)\}/g;
+var errorLabel = /^\[ERROR\]/gm;
 
 // Parse the output from 'mvn dependency:tree -DoutputType=dot'
 function parseTree(text, withDev) {
-  text = text.replace(logLabel, '');
-  try {
-    return {
-      ok: true,
-      data: getRootProject(text, withDev),
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      message: error.message,
-      error: error,
-    };
+  // check for errors in mvn output
+  if (errorLabel.test(text)) {
+    throw new Error('Failed to execute an `mvn` command.');
   }
+
+  // clear all labels
+  text = text.replace(logLabel, '');
+
+  // extract deps
+  var data = getRootProject(text, withDev);
+
+  return {ok: true, data: data};
 }
 
 function getRootProject(text, withDev) {
   var projects = text.match(digraph);
   if (!projects) {
-    throw new Error('Error: Cannot find dependency information. ' +
-                    'Please make sure that Apache Maven Dependency Plugin ' +
-                    'version 2.2 or above is installed.');
+    throw new Error('Cannot find dependency information.');
   }
   var root = getProject(projects[0], null, withDev);
   // Add any subsequent projects to the root as dependencies

--- a/test/fixtures/maven-dependency-tree-error.txt
+++ b/test/fixtures/maven-dependency-tree-error.txt
@@ -1,0 +1,19 @@
+[INFO] Scanning for projects...
+[INFO]
+[INFO] -----------------< some.group.id:some.artifact.id >-----------------
+[INFO] Building MyProject 1.0.0-SNAPSHOT
+[INFO] --------------------------------[ war ]---------------------------------
+[WARNING] The POM for another.group.id:another.artifact.id:jar:1.0 is missing, no dependency information available
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 1.191 s
+[INFO] Finished at: 2018-09-06T09:18:07-07:00
+[INFO] ------------------------------------------------------------------------
+[ERROR] Failed to execute goal on project MyProject: Could not resolve dependencies for project some.group.id:some.artifact.id:war:1.0.0-SNAPSHOT: Failure for some obscure reason
+[ERROR]
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR]
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException

--- a/test/functional/parse-mvn.test.js
+++ b/test/functional/parse-mvn.test.js
@@ -29,8 +29,26 @@ test('test with bad mvn dependency:tree output', function (t) {
   t.plan(1);
   var mavenOutput = fs.readFileSync(path.join(
     __dirname, '..', 'fixtures', 'maven-dependency-tree-bad.txt'), 'utf8');
-  var data = parse(mavenOutput, true);
-  t.equal(data.ok, false, 'bad output detected');
+  try {
+    parse(mavenOutput, true);
+    t.fail('Should have thrown!');
+  } catch (error) {
+    t.equal(error.message, 'Cannot find dependency information.',
+      'proper error message');
+  }
+});
+
+test('test with error mvn dependency:tree output', function (t) {
+  t.plan(1);
+  var mavenOutput = fs.readFileSync(path.join(
+    __dirname, '..', 'fixtures', 'maven-dependency-tree-error.txt'), 'utf8');
+  try {
+    parse(mavenOutput, true);
+    t.fail('Should have thrown!');
+  } catch (error) {
+    t.equal(error.message, 'Failed to execute an `mvn` command.',
+      'proper error message');
+  }
 });
 
 test('test with type "test-jar" in mvn dependency', function (t) {

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -34,8 +34,7 @@ test('run inspect() with a bad dependency plugin', function (t) {
       t.fail('bad dependency plugin - we should not be here');
     })
     .catch(function (error) {
-      t.equal(error, 'Error: Cannot find dependency information. ' +
-    'Please make sure that Apache Maven Dependency Plugin ' +
-    'version 2.2 or above is installed.', 'correct failure message');
+      t.match(error.message, 'Cannot find dependency information.',
+        'proper error message');
     });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The plugin throws a `string` on parsing failures. The CLI expects an `Error` object on plugin failures. This mismatch results in obscure user output such as:
```
For path `path/to/maven/project`, undefined
- Analyzing maven dependencies for pom.xml
```

This PR changes the behaviour of the plugin to reflect this, and adds a test case with an `[ERROR]` maven output for better verbosity.