### PR TITLE
fix: throw proper error on failing mvn execution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,25 +18,24 @@ function inspect(root, targetFile, options) {
   var mvnArgs = buildArgs(root, targetFile, options.args);
   return subProcess.execute('mvn', mvnArgs, {cwd: root})
     .then(function (result) {
-      try {
-        var parseResult = parse(result, options.dev);
-        return {
-          plugin: {
-            name: 'bundled:maven',
-            runtime: 'unknown',
-          },
-          package: parseResult.data,
-        };
-      } catch (error) {
-        error.message = error.message + '\n\n' +
-          'Please make sure that Apache Maven Dependency Plugin ' +
-          'version 2.2 or above is installed, and that ' +
-          '`mvn ' + mvnArgs.join(' ') + '` executes successfully ' +
-          'on this project.\n\n' +
-          'If the problem persists, collect the output of ' +
-          '`mvn ' + mvnArgs.join(' ') + '` and contact support@snyk.io\n';
-        throw error;
-      }
+      var parseResult = parse(result, options.dev);
+      return {
+        plugin: {
+          name: 'bundled:maven',
+          runtime: 'unknown',
+        },
+        package: parseResult.data,
+      };
+    })
+    .catch(function (error) {
+      error.message = error.message + '\n\n' +
+        'Please make sure that Apache Maven Dependency Plugin ' +
+        'version 2.2 or above is installed, and that ' +
+        '`mvn ' + mvnArgs.join(' ') + '` executes successfully ' +
+        'on this project.\n\n' +
+        'If the problem persists, collect the output of ' +
+        '`mvn ' + mvnArgs.join(' ') + '` and contact support@snyk.io\n';
+      throw error;
     });
 }
 

--- a/lib/sub-process.js
+++ b/lib/sub-process.js
@@ -20,7 +20,7 @@ module.exports.execute = function (command, args, options) {
 
     proc.on('close', function (code) {
       if (code !== 0) {
-        return reject(stdout || stderr);
+        return reject(new Error(stdout || stderr));
       }
       resolve(stdout || stderr);
     });

--- a/test/fixtures/bad-pom.xml
+++ b/test/fixtures/bad-pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>bad-test-project</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test project</name>
+  <description>Test project for the Maven CLI plugin</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>no.such.groupId</groupId>
+      <artifactId>no.such.artifactId</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -38,3 +38,16 @@ test('run inspect() with a bad dependency plugin', function (t) {
         'proper error message');
     });
 });
+
+test('run inspect() with a bad pom.xml', function (t) {
+  t.plan(1);
+  return plugin.inspect('.', path.join(
+    __dirname, '..', 'fixtures', 'bad-pom.xml'), {dev: true})
+    .then(function () {
+      t.fail('bad pom.xml - should have thrown!');
+    })
+    .catch(function (error) {
+      t.match(error.message, 'executes successfully on this project',
+        'proper error message');
+    });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When `mvn` execution ends with an error, the plugin used to reject with a string containing the stdout or stderr of the `mvn` process. This doesn't work well with the CLI, which expects proper `Error` objects on plugin failure. Now fixed!