### PR TITLE
test: extend timeout to let mvn more time to fail on new test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint -c .eslintrc lib test",
     "test": "npm run lint && npm run test-functional && npm run test-system",
     "test-functional": "tap ./test/functional/*.test.js -R spec",
-    "test-system": "tap ./test/system/*.test.js -R spec --timeout=60",
+    "test-system": "tap ./test/system/*.test.js -R spec --timeout=180",
     "semantic-release": "semantic-release"
   },
   "author": "snyk.io",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Extend timeout of system tests to accommodate a longer test that runs `mvn` in order to fail it.