### PR TITLE
BREAKING CHANGE: drop unused groupId and artifactId attributes from response

### DIFF
--- a/lib/parse-mvn.js
+++ b/lib/parse-mvn.js
@@ -82,9 +82,6 @@ function createPackage(pkgStr) {
 
   var parts = pkgStr.split(':');
   var result = {
-    groupId: parts[0],
-    artifactId: parts[1],
-    packaging: parts[2],
     version: parts[3],
     name: parts[0] + ':' + parts[1],
     dependencies: {},

--- a/test/fixtures/maven-parse-dev-results.json
+++ b/test/fixtures/maven-parse-dev-results.json
@@ -1,1 +1,202 @@
-{"groupId":"org.springframework.boot","artifactId":"spring-boot-starter-quartz","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-starter-quartz","dependencies":{"org.springframework.boot:spring-boot-starter":{"groupId":"org.springframework.boot","artifactId":"spring-boot-starter","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-starter","dependencies":{"org.springframework.boot:spring-boot":{"groupId":"org.springframework.boot","artifactId":"spring-boot","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot","dependencies":{},"scope":"compile"},"org.springframework.boot:spring-boot-autoconfigure":{"groupId":"org.springframework.boot","artifactId":"spring-boot-autoconfigure","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-autoconfigure","dependencies":{},"scope":"compile"},"org.springframework.boot:spring-boot-starter-logging":{"groupId":"org.springframework.boot","artifactId":"spring-boot-starter-logging","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-starter-logging","dependencies":{"ch.qos.logback:logback-classic":{"groupId":"ch.qos.logback","artifactId":"logback-classic","packaging":"jar","version":"1.2.3","name":"ch.qos.logback:logback-classic","dependencies":{"ch.qos.logback:logback-core":{"groupId":"ch.qos.logback","artifactId":"logback-core","packaging":"jar","version":"1.2.3","name":"ch.qos.logback:logback-core","dependencies":{},"scope":"compile"}},"scope":"compile"},"org.slf4j:jul-to-slf4j":{"groupId":"org.slf4j","artifactId":"jul-to-slf4j","packaging":"jar","version":"1.7.25","name":"org.slf4j:jul-to-slf4j","dependencies":{},"scope":"compile"},"org.slf4j:log4j-over-slf4j":{"groupId":"org.slf4j","artifactId":"log4j-over-slf4j","packaging":"jar","version":"1.7.25","name":"org.slf4j:log4j-over-slf4j","dependencies":{},"scope":"compile"}},"scope":"compile"},"org.springframework:spring-core":{"groupId":"org.springframework","artifactId":"spring-core","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-core","dependencies":{"org.springframework:spring-jcl":{"groupId":"org.springframework","artifactId":"spring-jcl","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-jcl","dependencies":{},"scope":"compile"}},"scope":"compile"},"org.yaml:snakeyaml":{"groupId":"org.yaml","artifactId":"snakeyaml","packaging":"jar","version":"1.18","name":"org.yaml:snakeyaml","dependencies":{},"scope":"runtime"}},"scope":"compile"},"org.springframework:spring-context-support":{"groupId":"org.springframework","artifactId":"spring-context-support","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-context-support","dependencies":{"org.springframework:spring-beans":{"groupId":"org.springframework","artifactId":"spring-beans","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-beans","dependencies":{},"scope":"compile"},"org.springframework:spring-context":{"groupId":"org.springframework","artifactId":"spring-context","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-context","dependencies":{"org.springframework:spring-aop":{"groupId":"org.springframework","artifactId":"spring-aop","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-aop","dependencies":{},"scope":"compile"},"org.springframework:spring-expression":{"groupId":"org.springframework","artifactId":"spring-expression","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-expression","dependencies":{},"scope":"compile"}},"scope":"compile"}},"scope":"compile"},"org.springframework:spring-tx":{"groupId":"org.springframework","artifactId":"spring-tx","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-tx","dependencies":{},"scope":"compile"},"org.quartz-scheduler:quartz":{"groupId":"org.quartz-scheduler","artifactId":"quartz","packaging":"jar","version":"2.3.0","name":"org.quartz-scheduler:quartz","dependencies":{"com.mchange:c3p0":{"groupId":"com.mchange","artifactId":"c3p0","packaging":"jar","version":"0.9.5.2","name":"com.mchange:c3p0","dependencies":{},"scope":"compile"},"com.mchange:mchange-commons-java":{"groupId":"com.mchange","artifactId":"mchange-commons-java","packaging":"jar","version":"0.2.11","name":"com.mchange:mchange-commons-java","dependencies":{},"scope":"compile"},"com.zaxxer:HikariCP-java6":{"groupId":"com.zaxxer","artifactId":"HikariCP-java6","packaging":"jar","version":"2.3.13","name":"com.zaxxer:HikariCP-java6","dependencies":{},"scope":"compile"},"org.slf4j:slf4j-api":{"groupId":"org.slf4j","artifactId":"slf4j-api","packaging":"jar","version":"1.7.25","name":"org.slf4j:slf4j-api","dependencies":{},"scope":"compile"}},"scope":"compile"},"junit:junit":{"groupId":"junit","artifactId":"junit","packaging":"jar","version":"4.12","name":"junit:junit","dependencies":{"org.hamcrest:hamcrest-core":{"groupId":"org.hamcrest","artifactId":"hamcrest-core","packaging":"jar","version":"1.3","name":"org.hamcrest:hamcrest-core","dependencies":{},"scope":"test"}},"scope":"test"},"org.assertj:assertj-core":{"groupId":"org.assertj","artifactId":"assertj-core","packaging":"jar","version":"3.8.0","name":"org.assertj:assertj-core","dependencies":{},"scope":"test"},"org.mockito:mockito-core":{"groupId":"org.mockito","artifactId":"mockito-core","packaging":"jar","version":"2.8.9","name":"org.mockito:mockito-core","dependencies":{"net.bytebuddy:byte-buddy":{"groupId":"net.bytebuddy","artifactId":"byte-buddy","packaging":"jar","version":"1.6.14","name":"net.bytebuddy:byte-buddy","dependencies":{},"scope":"test"},"net.bytebuddy:byte-buddy-agent":{"groupId":"net.bytebuddy","artifactId":"byte-buddy-agent","packaging":"jar","version":"1.6.14","name":"net.bytebuddy:byte-buddy-agent","dependencies":{},"scope":"test"},"org.objenesis:objenesis":{"groupId":"org.objenesis","artifactId":"objenesis","packaging":"jar","version":"2.5","name":"org.objenesis:objenesis","dependencies":{},"scope":"test"}},"scope":"test"},"org.hamcrest:hamcrest-library":{"groupId":"org.hamcrest","artifactId":"hamcrest-library","packaging":"jar","version":"1.3","name":"org.hamcrest:hamcrest-library","dependencies":{},"scope":"test"},"org.springframework:spring-test":{"groupId":"org.springframework","artifactId":"spring-test","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-test","dependencies":{},"scope":"test"}},"packageFormatVersion":"mvn:0.0.1"}
+{
+  "version": "2.0.0.BUILD-SNAPSHOT",
+  "name": "org.springframework.boot:spring-boot-starter-quartz",
+  "dependencies": {
+    "org.springframework.boot:spring-boot-starter": {
+      "version": "2.0.0.BUILD-SNAPSHOT",
+      "name": "org.springframework.boot:spring-boot-starter",
+      "dependencies": {
+        "org.springframework.boot:spring-boot": {
+          "version": "2.0.0.BUILD-SNAPSHOT",
+          "name": "org.springframework.boot:spring-boot",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+          "version": "2.0.0.BUILD-SNAPSHOT",
+          "name": "org.springframework.boot:spring-boot-autoconfigure",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+          "version": "2.0.0.BUILD-SNAPSHOT",
+          "name": "org.springframework.boot:spring-boot-starter-logging",
+          "dependencies": {
+            "ch.qos.logback:logback-classic": {
+              "version": "1.2.3",
+              "name": "ch.qos.logback:logback-classic",
+              "dependencies": {
+                "ch.qos.logback:logback-core": {
+                  "version": "1.2.3",
+                  "name": "ch.qos.logback:logback-core",
+                  "dependencies": {},
+                  "scope": "compile"
+                }
+              },
+              "scope": "compile"
+            },
+            "org.slf4j:jul-to-slf4j": {
+              "version": "1.7.25",
+              "name": "org.slf4j:jul-to-slf4j",
+              "dependencies": {},
+              "scope": "compile"
+            },
+            "org.slf4j:log4j-over-slf4j": {
+              "version": "1.7.25",
+              "name": "org.slf4j:log4j-over-slf4j",
+              "dependencies": {},
+              "scope": "compile"
+            }
+          },
+          "scope": "compile"
+        },
+        "org.springframework:spring-core": {
+          "version": "5.0.0.RC2",
+          "name": "org.springframework:spring-core",
+          "dependencies": {
+            "org.springframework:spring-jcl": {
+              "version": "5.0.0.RC2",
+              "name": "org.springframework:spring-jcl",
+              "dependencies": {},
+              "scope": "compile"
+            }
+          },
+          "scope": "compile"
+        },
+        "org.yaml:snakeyaml": {
+          "version": "1.18",
+          "name": "org.yaml:snakeyaml",
+          "dependencies": {},
+          "scope": "runtime"
+        }
+      },
+      "scope": "compile"
+    },
+    "org.springframework:spring-context-support": {
+      "version": "5.0.0.RC2",
+      "name": "org.springframework:spring-context-support",
+      "dependencies": {
+        "org.springframework:spring-beans": {
+          "version": "5.0.0.RC2",
+          "name": "org.springframework:spring-beans",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.springframework:spring-context": {
+          "version": "5.0.0.RC2",
+          "name": "org.springframework:spring-context",
+          "dependencies": {
+            "org.springframework:spring-aop": {
+              "version": "5.0.0.RC2",
+              "name": "org.springframework:spring-aop",
+              "dependencies": {},
+              "scope": "compile"
+            },
+            "org.springframework:spring-expression": {
+              "version": "5.0.0.RC2",
+              "name": "org.springframework:spring-expression",
+              "dependencies": {},
+              "scope": "compile"
+            }
+          },
+          "scope": "compile"
+        }
+      },
+      "scope": "compile"
+    },
+    "org.springframework:spring-tx": {
+      "version": "5.0.0.RC2",
+      "name": "org.springframework:spring-tx",
+      "dependencies": {},
+      "scope": "compile"
+    },
+    "org.quartz-scheduler:quartz": {
+      "version": "2.3.0",
+      "name": "org.quartz-scheduler:quartz",
+      "dependencies": {
+        "com.mchange:c3p0": {
+          "version": "0.9.5.2",
+          "name": "com.mchange:c3p0",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "com.mchange:mchange-commons-java": {
+          "version": "0.2.11",
+          "name": "com.mchange:mchange-commons-java",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "com.zaxxer:HikariCP-java6": {
+          "version": "2.3.13",
+          "name": "com.zaxxer:HikariCP-java6",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.slf4j:slf4j-api": {
+          "version": "1.7.25",
+          "name": "org.slf4j:slf4j-api",
+          "dependencies": {},
+          "scope": "compile"
+        }
+      },
+      "scope": "compile"
+    },
+    "junit:junit": {
+      "version": "4.12",
+      "name": "junit:junit",
+      "dependencies": {
+        "org.hamcrest:hamcrest-core": {
+          "version": "1.3",
+          "name": "org.hamcrest:hamcrest-core",
+          "dependencies": {},
+          "scope": "test"
+        }
+      },
+      "scope": "test"
+    },
+    "org.assertj:assertj-core": {
+      "version": "3.8.0",
+      "name": "org.assertj:assertj-core",
+      "dependencies": {},
+      "scope": "test"
+    },
+    "org.mockito:mockito-core": {
+      "version": "2.8.9",
+      "name": "org.mockito:mockito-core",
+      "dependencies": {
+        "net.bytebuddy:byte-buddy": {
+          "version": "1.6.14",
+          "name": "net.bytebuddy:byte-buddy",
+          "dependencies": {},
+          "scope": "test"
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+          "version": "1.6.14",
+          "name": "net.bytebuddy:byte-buddy-agent",
+          "dependencies": {},
+          "scope": "test"
+        },
+        "org.objenesis:objenesis": {
+          "version": "2.5",
+          "name": "org.objenesis:objenesis",
+          "dependencies": {},
+          "scope": "test"
+        }
+      },
+      "scope": "test"
+    },
+    "org.hamcrest:hamcrest-library": {
+      "version": "1.3",
+      "name": "org.hamcrest:hamcrest-library",
+      "dependencies": {},
+      "scope": "test"
+    },
+    "org.springframework:spring-test": {
+      "version": "5.0.0.RC2",
+      "name": "org.springframework:spring-test",
+      "dependencies": {},
+      "scope": "test"
+    }
+  },
+  "packageFormatVersion": "mvn:0.0.1"
+}

--- a/test/fixtures/maven-parse-results.json
+++ b/test/fixtures/maven-parse-results.json
@@ -1,1 +1,146 @@
-{"groupId":"org.springframework.boot","artifactId":"spring-boot-starter-quartz","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-starter-quartz","dependencies":{"org.springframework.boot:spring-boot-starter":{"groupId":"org.springframework.boot","artifactId":"spring-boot-starter","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-starter","dependencies":{"org.springframework.boot:spring-boot":{"groupId":"org.springframework.boot","artifactId":"spring-boot","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot","dependencies":{},"scope":"compile"},"org.springframework.boot:spring-boot-autoconfigure":{"groupId":"org.springframework.boot","artifactId":"spring-boot-autoconfigure","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-autoconfigure","dependencies":{},"scope":"compile"},"org.springframework.boot:spring-boot-starter-logging":{"groupId":"org.springframework.boot","artifactId":"spring-boot-starter-logging","packaging":"jar","version":"2.0.0.BUILD-SNAPSHOT","name":"org.springframework.boot:spring-boot-starter-logging","dependencies":{"ch.qos.logback:logback-classic":{"groupId":"ch.qos.logback","artifactId":"logback-classic","packaging":"jar","version":"1.2.3","name":"ch.qos.logback:logback-classic","dependencies":{"ch.qos.logback:logback-core":{"groupId":"ch.qos.logback","artifactId":"logback-core","packaging":"jar","version":"1.2.3","name":"ch.qos.logback:logback-core","dependencies":{},"scope":"compile"}},"scope":"compile"},"org.slf4j:jul-to-slf4j":{"groupId":"org.slf4j","artifactId":"jul-to-slf4j","packaging":"jar","version":"1.7.25","name":"org.slf4j:jul-to-slf4j","dependencies":{},"scope":"compile"},"org.slf4j:log4j-over-slf4j":{"groupId":"org.slf4j","artifactId":"log4j-over-slf4j","packaging":"jar","version":"1.7.25","name":"org.slf4j:log4j-over-slf4j","dependencies":{},"scope":"compile"}},"scope":"compile"},"org.springframework:spring-core":{"groupId":"org.springframework","artifactId":"spring-core","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-core","dependencies":{"org.springframework:spring-jcl":{"groupId":"org.springframework","artifactId":"spring-jcl","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-jcl","dependencies":{},"scope":"compile"}},"scope":"compile"},"org.yaml:snakeyaml":{"groupId":"org.yaml","artifactId":"snakeyaml","packaging":"jar","version":"1.18","name":"org.yaml:snakeyaml","dependencies":{},"scope":"runtime"}},"scope":"compile"},"org.springframework:spring-context-support":{"groupId":"org.springframework","artifactId":"spring-context-support","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-context-support","dependencies":{"org.springframework:spring-beans":{"groupId":"org.springframework","artifactId":"spring-beans","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-beans","dependencies":{},"scope":"compile"},"org.springframework:spring-context":{"groupId":"org.springframework","artifactId":"spring-context","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-context","dependencies":{"org.springframework:spring-aop":{"groupId":"org.springframework","artifactId":"spring-aop","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-aop","dependencies":{},"scope":"compile"},"org.springframework:spring-expression":{"groupId":"org.springframework","artifactId":"spring-expression","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-expression","dependencies":{},"scope":"compile"}},"scope":"compile"}},"scope":"compile"},"org.springframework:spring-tx":{"groupId":"org.springframework","artifactId":"spring-tx","packaging":"jar","version":"5.0.0.RC2","name":"org.springframework:spring-tx","dependencies":{},"scope":"compile"},"org.quartz-scheduler:quartz":{"groupId":"org.quartz-scheduler","artifactId":"quartz","packaging":"jar","version":"2.3.0","name":"org.quartz-scheduler:quartz","dependencies":{"com.mchange:c3p0":{"groupId":"com.mchange","artifactId":"c3p0","packaging":"jar","version":"0.9.5.2","name":"com.mchange:c3p0","dependencies":{},"scope":"compile"},"com.mchange:mchange-commons-java":{"groupId":"com.mchange","artifactId":"mchange-commons-java","packaging":"jar","version":"0.2.11","name":"com.mchange:mchange-commons-java","dependencies":{},"scope":"compile"},"com.zaxxer:HikariCP-java6":{"groupId":"com.zaxxer","artifactId":"HikariCP-java6","packaging":"jar","version":"2.3.13","name":"com.zaxxer:HikariCP-java6","dependencies":{},"scope":"compile"},"org.slf4j:slf4j-api":{"groupId":"org.slf4j","artifactId":"slf4j-api","packaging":"jar","version":"1.7.25","name":"org.slf4j:slf4j-api","dependencies":{},"scope":"compile"}},"scope":"compile"}},"packageFormatVersion":"mvn:0.0.1"}
+{
+  "version": "2.0.0.BUILD-SNAPSHOT",
+  "name": "org.springframework.boot:spring-boot-starter-quartz",
+  "dependencies": {
+    "org.springframework.boot:spring-boot-starter": {
+      "version": "2.0.0.BUILD-SNAPSHOT",
+      "name": "org.springframework.boot:spring-boot-starter",
+      "dependencies": {
+        "org.springframework.boot:spring-boot": {
+          "version": "2.0.0.BUILD-SNAPSHOT",
+          "name": "org.springframework.boot:spring-boot",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+          "version": "2.0.0.BUILD-SNAPSHOT",
+          "name": "org.springframework.boot:spring-boot-autoconfigure",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+          "version": "2.0.0.BUILD-SNAPSHOT",
+          "name": "org.springframework.boot:spring-boot-starter-logging",
+          "dependencies": {
+            "ch.qos.logback:logback-classic": {
+              "version": "1.2.3",
+              "name": "ch.qos.logback:logback-classic",
+              "dependencies": {
+                "ch.qos.logback:logback-core": {
+                  "version": "1.2.3",
+                  "name": "ch.qos.logback:logback-core",
+                  "dependencies": {},
+                  "scope": "compile"
+                }
+              },
+              "scope": "compile"
+            },
+            "org.slf4j:jul-to-slf4j": {
+              "version": "1.7.25",
+              "name": "org.slf4j:jul-to-slf4j",
+              "dependencies": {},
+              "scope": "compile"
+            },
+            "org.slf4j:log4j-over-slf4j": {
+              "version": "1.7.25",
+              "name": "org.slf4j:log4j-over-slf4j",
+              "dependencies": {},
+              "scope": "compile"
+            }
+          },
+          "scope": "compile"
+        },
+        "org.springframework:spring-core": {
+          "version": "5.0.0.RC2",
+          "name": "org.springframework:spring-core",
+          "dependencies": {
+            "org.springframework:spring-jcl": {
+              "version": "5.0.0.RC2",
+              "name": "org.springframework:spring-jcl",
+              "dependencies": {},
+              "scope": "compile"
+            }
+          },
+          "scope": "compile"
+        },
+        "org.yaml:snakeyaml": {
+          "version": "1.18",
+          "name": "org.yaml:snakeyaml",
+          "dependencies": {},
+          "scope": "runtime"
+        }
+      },
+      "scope": "compile"
+    },
+    "org.springframework:spring-context-support": {
+      "version": "5.0.0.RC2",
+      "name": "org.springframework:spring-context-support",
+      "dependencies": {
+        "org.springframework:spring-beans": {
+          "version": "5.0.0.RC2",
+          "name": "org.springframework:spring-beans",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.springframework:spring-context": {
+          "version": "5.0.0.RC2",
+          "name": "org.springframework:spring-context",
+          "dependencies": {
+            "org.springframework:spring-aop": {
+              "version": "5.0.0.RC2",
+              "name": "org.springframework:spring-aop",
+              "dependencies": {},
+              "scope": "compile"
+            },
+            "org.springframework:spring-expression": {
+              "version": "5.0.0.RC2",
+              "name": "org.springframework:spring-expression",
+              "dependencies": {},
+              "scope": "compile"
+            }
+          },
+          "scope": "compile"
+        }
+      },
+      "scope": "compile"
+    },
+    "org.springframework:spring-tx": {
+      "version": "5.0.0.RC2",
+      "name": "org.springframework:spring-tx",
+      "dependencies": {},
+      "scope": "compile"
+    },
+    "org.quartz-scheduler:quartz": {
+      "version": "2.3.0",
+      "name": "org.quartz-scheduler:quartz",
+      "dependencies": {
+        "com.mchange:c3p0": {
+          "version": "0.9.5.2",
+          "name": "com.mchange:c3p0",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "com.mchange:mchange-commons-java": {
+          "version": "0.2.11",
+          "name": "com.mchange:mchange-commons-java",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "com.zaxxer:HikariCP-java6": {
+          "version": "2.3.13",
+          "name": "com.zaxxer:HikariCP-java6",
+          "dependencies": {},
+          "scope": "compile"
+        },
+        "org.slf4j:slf4j-api": {
+          "version": "1.7.25",
+          "name": "org.slf4j:slf4j-api",
+          "dependencies": {},
+          "scope": "compile"
+        }
+      },
+      "scope": "compile"
+    }
+  },
+  "packageFormatVersion": "mvn:0.0.1"
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- removes unused `groupId` and `artifactId` from response
- also removes "packaging" attribute

#### Any background context you want to provide?

- the current dependency tree format is very verbose and this gives us a tiny bit more headroom for large projects
