### PR TITLE
Fix/path with space

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,9 +44,9 @@ function buildArgs(root, targetFile, mavenArgs) {
   var args = ['dependency:tree', '-DoutputType=dot'];
   if (targetFile) {
     if (!fs.existsSync(path.resolve(root, targetFile))) {
-      throw new Error('File not found: ' + targetFile);
+      throw new Error('File not found: "' + targetFile + '"');
     }
-    args.push('--file=' + targetFile);
+    args.push('--file="' + targetFile + '"');
   }
   if (mavenArgs) {
     args = args.concat(mavenArgs);

--- a/test/fixtures/path with spaces/pom.xml
+++ b/test/fixtures/path with spaces/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>test-project</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test project</name>
+  <description>Test project for the Maven CLI plugin</description>
+
+  <properties>
+    <axis.version>1.4</axis.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis</artifactId>
+      <version>${axis.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/test/system/plugin.test.js
+++ b/test/system/plugin.test.js
@@ -14,6 +14,18 @@ test('run inspect()', function (t) {
     });
 });
 
+test('run inspect() on path with spaces', function (t) {
+  t.plan(2);
+  return plugin.inspect('.', path.join(
+    __dirname, '..', 'fixtures/path with spaces', 'pom.xml'))
+    .then(function (result) {
+      t.equal(result.package.dependencies['axis:axis'].version, '1.4',
+        'correct version found');
+      t.type(result.package.dependencies['junit:junit'], 'undefined',
+        'no test deps');
+    });
+});
+
 test('run inspect() with --dev', function (t) {
   t.plan(2);
   return plugin.inspect('.', path.join(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The plugin failed to process a project whose target file path had spaces. That is `inspect('.', 'path with space/to/pom.xml, options)` would fail.

Fixing this by quoting the target file path when creating the `mvn` command args.