### PR TITLE
docs: clarify usage of plugin is not to be used as standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
 
+| :information_source: This repository is only a plugin to be used with the Snyk CLI tool. To use this plugin to test and fix vulnerabilities in your project, install the Snyk CLI tool first. Head over to [snyk.io](https://github.com/snyk/snyk) to get started. |
+| --- |
+
+
 ## Snyk Maven CLI Plugin
 
 This plugin provides dependency metadata for Maven projects that use mvn and have a pom.xml file. It is an internal component intended for use by our [CLI tool](https://github.com/snyk/snyk).


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds clarification that the purpose of the plugin is not to be used as a standalone app, but instead use the Snyk CLI tool instead

#### What are the relevant tickets?
#39 