### PR TITLE
fix: add request lib to mvn plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@snyk/cli-interface": "2.2.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
+    "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
     "tmp": "^0.1.0",
     "tslib": "1.9.3"


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add `request` lib, cos it is peer dependency of `request-promise-native`