### PR TITLE
feat: add java and maven version to metadata

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import { parseTree } from './parse-mvn';
+import { parseTree, parseVersions } from './parse-mvn';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as subProcess from './sub-process';
@@ -40,11 +40,23 @@ export async function inspect(
   const mvnArgs = buildArgs(targetFile, options.args);
   try {
     const result = await subProcess.execute('mvn', mvnArgs, { cwd: root });
+    const versionResult = await subProcess.execute('mvn --version', [], {
+      cwd: root,
+    });
     const parseResult = parseTree(result, options.dev);
+    const { javaVersion, mavenVersion } = parseVersions(versionResult);
     return {
       plugin: {
         name: 'bundled:maven',
         runtime: 'unknown',
+        meta: {
+          versionBuildInfo: {
+            metaBuildVersion: {
+              mavenVersion,
+              javaVersion,
+            },
+          },
+        },
       },
       package: parseResult.data,
     };

--- a/lib/parse-mvn.ts
+++ b/lib/parse-mvn.ts
@@ -1,4 +1,5 @@
 import { legacyCommon } from '@snyk/cli-interface';
+import * as os from 'os';
 
 const newline = /[\r\n]+/g;
 const logLabel = /^\[\w+\]\s*/gm;
@@ -19,6 +20,18 @@ export function parseTree(text: string, withDev) {
   const data = getRootProject(text, withDev);
 
   return { ok: true, data };
+}
+
+export function parseVersions(
+  text: string,
+): { javaVersion: string; mavenVersion: string } {
+  // AppVeyor (at least) doesn't use \n\r, therefore os.EOL doesn't work
+  const data = text.split('\n');
+  const mavenVersion = data[0];
+  const javaVersion =
+    data.find((line) => line.startsWith('Java version:')) || '';
+
+  return { javaVersion, mavenVersion };
 }
 
 function getRootProject(text, withDev) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "@snyk/cli-interface": "2.3.0",
+    "@snyk/cli-interface": "2.3.1",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
     "needle": "^2.4.0",

--- a/tests/fixtures/parse-mvn/maven-versions.txt
+++ b/tests/fixtures/parse-mvn/maven-versions.txt
@@ -1,0 +1,5 @@
+Apache Maven 3.6.2 (40f52333136460af0dc0d7232c0dc0bcf0d9e117; 2019-08-27T17:06:16+02:00)
+Maven home: /usr/local/Cellar/maven/3.6.2/libexec
+Java version: 12.0.1, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/openjdk-12.0.1.jdk/Contents/Home
+Default locale: en_GB, platform encoding: UTF-8
+OS name: "mac os x", version: "10.15.2", arch: "x86_64", family: "mac"

--- a/tests/functional/parse-mvn.test.ts
+++ b/tests/functional/parse-mvn.test.ts
@@ -1,6 +1,6 @@
 import * as test from 'tap-only';
 import { readFixture, readFixtureJSON } from '../file-helper';
-import { parseTree } from '../../lib/parse-mvn';
+import { parseTree, parseVersions } from '../../lib/parse-mvn';
 
 test('parseTree without --dev', async (t) => {
   const mavenOutput = await readFixture(
@@ -63,6 +63,23 @@ test('parseTree with type "test-jar" in mvn dependency', async (t) => {
     t.equals(
       result.data.dependencies['com.snyk.tester:tester-queue'].version,
       '15.0.0',
+    );
+  } else {
+    t.fail('result.data.dependencies was empty');
+  }
+});
+
+test('parseVersions from mvn --version', async (t) => {
+  const mavenOutput = await readFixture('parse-mvn/maven-versions.txt');
+  const result = parseVersions(mavenOutput);
+  if (result) {
+    t.equals(
+      result.javaVersion,
+      'Java version: 12.0.1, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/openjdk-12.0.1.jdk/Contents/Home',
+    );
+    t.equals(
+      result.mavenVersion,
+      'Apache Maven 3.6.2 (40f52333136460af0dc0d7232c0dc0bcf0d9e117; 2019-08-27T17:06:16+02:00)',
     );
   } else {
     t.fail('result.data.dependencies was empty');

--- a/tests/system/plugin-jar.test.ts
+++ b/tests/system/plugin-jar.test.ts
@@ -18,6 +18,17 @@ test('inspect with spring-core jar file', async (t) => {
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('spring-core', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -75,6 +86,17 @@ test('inspect in directory with jars no target file and --scan-all-unmanaged arg
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('jars', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -86,6 +108,17 @@ test('inspect on target pom file in directory with jars and --scan-all-unmanaged
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('jars', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(
     result,
     expected,
@@ -114,5 +147,16 @@ test('inspect in directory with good and bad jars and --scan-all-unmanaged arg',
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('good-and-bad', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return good dependency, with bad ignored');
 });

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -17,6 +17,17 @@ test('inspect on test-project pom', async (t) => {
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('test-project', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -35,6 +46,17 @@ test('inspect on test-project pom with --dev', async (t) => {
     'test-project',
     'expected-with-dev.json',
   );
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -47,6 +69,17 @@ test('inspect on path with spaces pom', async (t) => {
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('path with spaces', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -59,6 +92,17 @@ test('inspect on relative path to test-project pom', async (t) => {
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('test-project', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -71,6 +115,17 @@ test('inspect on relative path to test-project dir', async (t) => {
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('test-project', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // once checked, compare platform-independent properties only
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 
@@ -80,6 +135,17 @@ test('inspect on root that contains pom.xml and no target file', async (t) => {
     return t.fail('expected single inspect result');
   }
   const expected = await readFixtureJSON('test-project', 'expected.json');
+  // result.metadata depends on platform, so no fixture can be provided
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.javaVersion,
+    'should contain javaVersion key',
+  );
+  t.ok(
+    result!.plugin!.meta!.versionBuildInfo!.metaBuildVersion!.mavenVersion,
+    'should contain mavenVersion key',
+  );
+  // therefore, only independent objects are compared
+  delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
 });
 


### PR DESCRIPTION
For better analytic insight into our userbase, we'd like to have an
overview about java and maven versions used. Prereq: https://github.com/snyk/snyk-cli-interface/pull/25

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team