### PR TITLE
feat/support reachable vulns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,14 @@ jobs:
         - sdk install maven $MAVEN_VERSION
         - java -version
         - npm test
+    - node_js: 12
+      env: MAVEN_VERSION=3.6.1 JDK=11
+      script:
+        - source install-jdk.sh --feature $JDK
+        - ln -sf /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
+        - sdk install maven $MAVEN_VERSION
+        - java -version
+        - npm test
     - stage: Older Maven version
       env: MAVEN_VERSION=3.3.9 JDK=8
       script:

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,15 +1,15 @@
-import { parseTree, parseVersions } from './parse-mvn';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as subProcess from './sub-process';
 import { legacyPlugin } from '@snyk/cli-interface';
 import { CallGraph } from '@snyk/cli-interface/legacy/common';
-
 import * as javaCallGraphBuilder from '@snyk/java-call-graph-builder';
-import { containsJar, createPomForJar, createPomForJars, isJar } from './jar';
 import * as os from 'os';
-
+import * as fs from 'fs';
+import * as path from 'path';
 import debugLib = require('debug');
+
+import { parseTree, parseVersions } from './parse-mvn';
+import * as subProcess from './sub-process';
+import { containsJar, createPomForJar, createPomForJars, isJar } from './jar';
+
 const debug = debugLib('snyk-mvn-plugin');
 
 export interface MavenOptions extends legacyPlugin.BaseInspectOptions {

--- a/package.json
+++ b/package.json
@@ -27,19 +27,20 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "11.13.8",
+    "@types/sinon": "^7.5.2",
     "@typescript-eslint/eslint-plugin": "^2.8.0",
     "@typescript-eslint/parser": "^2.8.0",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.7.0",
     "prettier": "^1.19.1",
-    "@types/sinon": "^7.0.10",
     "semantic-release": "^15",
     "sinon": "^2.4.1",
     "tap": "^12.0.1",
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "@snyk/cli-interface": "2.3.1",
+    "@snyk/cli-interface": "2.4.0",
+    "@snyk/java-call-graph-builder": "^1.3.4",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
     "needle": "^2.4.0",

--- a/tests/fixtures/call-graphs/simple.json
+++ b/tests/fixtures/call-graphs/simple.json
@@ -1,0 +1,33 @@
+{
+  "options": {
+    "directed": true,
+    "multigraph": false,
+    "compound": false
+  },
+  "nodes": [
+    {
+      "v": "com.ibm.wala.FakeRootClass:fakeRootMethod",
+      "value": {
+        "className": "com.ibm.wala.FakeRootClass",
+        "functionName": "fakeRootMethod"
+      }
+    },
+    {
+      "v": "ch.qos.logback.classic.net.SocketNode:run",
+      "value": {
+        "className": "ch.qos.logback.classic.net.SocketNode",
+        "functionName": "run"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "v": "com.ibm.wala.FakeRootClass:fakeRootMethod",
+      "w": "com.ibm.wala.FakeRootClass:fakeWorldClinit"
+    },
+    {
+      "v": "ch.qos.logback.classic.net.SocketNode",
+      "w": "com.ibm.wala.FakeRootClass:fakeWorldClinit"
+    }
+  ]
+}

--- a/tests/fixtures/good-and-bad/expected.json
+++ b/tests/fixtures/good-and-bad/expected.json
@@ -17,5 +17,6 @@
   "plugin": {
     "name": "bundled:maven",
     "runtime": "unknown"
-  }
+  },
+  "callGraph": null
 }

--- a/tests/fixtures/jar-wrong-package-name/expected.json
+++ b/tests/fixtures/jar-wrong-package-name/expected.json
@@ -17,5 +17,6 @@
   "plugin": {
     "name": "bundled:maven",
     "runtime": "unknown"
-  }
+  },
+  "callGraph": null
 }

--- a/tests/fixtures/jars/expected.json
+++ b/tests/fixtures/jars/expected.json
@@ -56,5 +56,6 @@
       }
     },
     "packageFormatVersion": "mvn:0.0.1"
-  }
+  },
+  "callGraph": null
 }

--- a/tests/fixtures/path with spaces/expected.json
+++ b/tests/fixtures/path with spaces/expected.json
@@ -1,5 +1,6 @@
 {
   "plugin": { "name": "bundled:maven", "runtime": "unknown" },
+  "callGraph": null,
   "package": {
     "name": "io.snyk.example:test-project",
     "version": "1.0-SNAPSHOT",

--- a/tests/fixtures/spring-core/expected.json
+++ b/tests/fixtures/spring-core/expected.json
@@ -19,5 +19,6 @@
       }
     },
     "packageFormatVersion": "mvn:0.0.1"
-  }
+  },
+  "callGraph": null
 }

--- a/tests/fixtures/test-project/expected-with-call-graph.json
+++ b/tests/fixtures/test-project/expected-with-call-graph.json
@@ -1,6 +1,38 @@
 {
   "plugin": { "name": "bundled:maven", "runtime": "unknown" },
-  "callGraph": null,
+  "callGraph": {
+    "options": {
+      "directed": true,
+      "multigraph": false,
+      "compound": false
+    },
+    "nodes": [
+      {
+        "v": "com.ibm.wala.FakeRootClass:fakeRootMethod",
+        "value": {
+          "className": "com.ibm.wala.FakeRootClass",
+          "functionName": "fakeRootMethod"
+        }
+      },
+      {
+        "v": "ch.qos.logback.classic.net.SocketNode:run",
+        "value": {
+          "className": "ch.qos.logback.classic.net.SocketNode",
+          "functionName": "run"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "v": "com.ibm.wala.FakeRootClass:fakeRootMethod",
+        "w": "com.ibm.wala.FakeRootClass:fakeWorldClinit"
+      },
+      {
+        "v": "ch.qos.logback.classic.net.SocketNode",
+        "w": "com.ibm.wala.FakeRootClass:fakeWorldClinit"
+      }
+    ]
+  },
   "package": {
     "name": "io.snyk.example:test-project",
     "version": "1.0-SNAPSHOT",

--- a/tests/fixtures/test-project/expected-with-dev.json
+++ b/tests/fixtures/test-project/expected-with-dev.json
@@ -1,5 +1,6 @@
 {
   "plugin": { "name": "bundled:maven", "runtime": "unknown" },
+  "callGraph": null,
   "package": {
     "name": "io.snyk.example:test-project",
     "version": "1.0-SNAPSHOT",

--- a/tests/fixtures/test-project/expected.json
+++ b/tests/fixtures/test-project/expected.json
@@ -1,5 +1,6 @@
 {
   "plugin": { "name": "bundled:maven", "runtime": "unknown" },
+  "callGraph": null,
   "package": {
     "name": "io.snyk.example:test-project",
     "version": "1.0-SNAPSHOT",

--- a/tests/system/get-command.test.ts
+++ b/tests/system/get-command.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { test, Test } from 'tap';
+import { test } from 'tap';
 import { getCommand } from '../../lib';
 import * as os from 'os';
 

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -9,7 +9,6 @@ import * as os from 'os';
 import * as plugin from '../../lib';
 import { readFixtureJSON } from '../file-helper';
 
-// TODO update cli interface package
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');
 const testProjectPath = path.join(fixturesPath, 'test-project');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
If the `--reachable-vulns` flag is being passed from the CLI,
the plugin will create a functions call graph and pass it
back to the CLI.

The way the graph is The java call graph builder generated
is by downloading a jar that will produce the call graph.
The jar is only downloaded if needed, more about this logic
is in https://github.com/snyk/java-call-graph-builder

Also, add node 12 to the test matrix.

#### Any background context you want to provide?
The tests are failing due the dependency (java-call-graph-builder) not supporting node 8, working on this in the meanwhile.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-159


#### Screenshots


#### Additional questions
