### PR TITLE
feat: better call graph errors

### DIFF
--- a/lib/error-format.ts
+++ b/lib/error-format.ts
@@ -1,0 +1,32 @@
+export function formatCallGraphError(error: Error): string {
+  if (error.message === 'Could not find target folder') {
+    return 'Failed to scan for reachable vulns. Please compile your code by running `mvn compile` and try again.';
+  }
+  if (error.message === 'No entrypoints found') {
+    return 'Failed to scan for reachable vulns. Couldn\'t find the application entry point.';
+  }
+  return 'Failed to scan for reachable vulns. Please contact our support or submit an issue at https://github.com/snyk/java-call-graph-builder/issues.';
+}
+
+export function formatGenericPluginError(
+  error: Error,
+  mavenCommand: string,
+  mvnArgs: string[],
+): string {
+  const fullCommand = [mavenCommand, ...mvnArgs].join(' ');
+  const mvnwCommandTipMessage =
+    'Currently, you cannot run `mvnw` outside your current directory, you will have to go inside the directory of your project (see: https://github.com/takari/maven-wrapper/issues/133)\n\n';
+  return (
+    error.message +
+    '\n\n' +
+    'Please make sure that Apache Maven Dependency Plugin ' +
+    'version 2.2 or above is installed, and that `' +
+    fullCommand +
+    '` executes successfully ' +
+    'on this project.\n\n' +
+    (mavenCommand.indexOf('mvnw') >= 0 ? mvnwCommandTipMessage : '') +
+    'If the problem persists, collect the output of `' +
+    fullCommand +
+    '` and contact support@snyk.io\n'
+  );
+}

--- a/lib/errors/call-graph-error.ts
+++ b/lib/errors/call-graph-error.ts
@@ -1,0 +1,10 @@
+import { CustomError } from './custom-error';
+
+export class CallGraphError extends CustomError {
+  public readonly innerError;
+
+  public constructor(message: string, innerError: Error) {
+    super(message);
+    this.innerError = innerError;
+  }
+}

--- a/lib/errors/custom-error.ts
+++ b/lib/errors/custom-error.ts
@@ -1,0 +1,12 @@
+export class CustomError extends Error {
+  public innerError?: Error;
+  public statusCode?: number;
+
+  public constructor(message: string, statusCode?: number) {
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.innerError = undefined;
+    this.statusCode = statusCode;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@snyk/cli-interface": "2.4.0",
-    "@snyk/java-call-graph-builder": "^1.3.4",
+    "@snyk/java-call-graph-builder": "1.4.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
     "needle": "^2.4.0",

--- a/tests/functional/error-format.test.ts
+++ b/tests/functional/error-format.test.ts
@@ -1,0 +1,53 @@
+import * as test from 'tap-only';
+
+import {
+  formatCallGraphError,
+  formatGenericPluginError,
+} from '../../lib/error-format';
+import { CallGraphError } from '../../lib/errors/call-graph-error';
+
+test('formatCallGraphError - not target folder', (t) => {
+  const err = new CallGraphError('Could not find target folder', new Error());
+  t.equals(
+    formatCallGraphError(err),
+    'Failed to scan for reachable vulns. Please compile your code by running `mvn compile` and try again.',
+    'correct error for no target folder',
+  );
+  t.end();
+});
+
+test('formatCallGraphError - not entrypoints', (t) => {
+  const err = new CallGraphError('No entrypoints found', new Error());
+  t.equals(
+    formatCallGraphError(err),
+    "Failed to scan for reachable vulns. Couldn't find the application entry point.",
+    'correct error for no target folder',
+  );
+  t.end();
+});
+
+test('formatCallGraphError - generic call graph error', (t) => {
+  const err = new CallGraphError('Some call graph error', new Error());
+  t.equals(
+    formatCallGraphError(err),
+    'Failed to scan for reachable vulns. Please contact our support or submit ' +
+      'an issue at https://github.com/snyk/java-call-graph-builder/issues.',
+    'correct error for generic call graph error',
+  );
+  t.end();
+});
+
+test('formatGenericPluginError - generic call graph error', (t) => {
+  const err = new Error('Some Generic Plugin Error');
+  t.equals(
+    formatGenericPluginError(err, 'mvn cmd', ['arg1', 'arg2']),
+    'Some Generic Plugin Error\n' +
+      '\n' +
+      'Please make sure that Apache Maven Dependency Plugin version 2.2 or above is installed, ' +
+      'and that `mvn cmd arg1 arg2` executes successfully on this project.\n' +
+      '\n' +
+      'If the problem persists, collect the output of `mvn cmd arg1 arg2` and contact support@snyk.io\n',
+    'correct error for generic plugin error',
+  );
+  t.end();
+});

--- a/tests/system/plugin-reachable-vulns.test.ts
+++ b/tests/system/plugin-reachable-vulns.test.ts
@@ -1,0 +1,76 @@
+import * as path from 'path';
+import * as test from 'tap-only';
+import * as sinon from 'sinon';
+import * as javaCallGraphBuilder from '@snyk/java-call-graph-builder';
+import { CallGraph } from '@snyk/cli-interface/legacy/common';
+
+import * as plugin from '../../lib';
+import { readFixtureJSON } from '../file-helper';
+
+const testsPath = path.join(__dirname, '..');
+const fixturesPath = path.join(testsPath, 'fixtures');
+const testProjectPath = path.join(fixturesPath, 'test-project');
+
+test('inspect on test-project pom with reachable vulns no entry points found', async (t) => {
+  const javaCallGraphBuilderStub = sinon
+    .stub(javaCallGraphBuilder, 'getCallGraphMvn')
+    .rejects(new Error('No entrypoints found'));
+
+  t.tearDown(() => {
+    javaCallGraphBuilderStub.restore();
+  });
+
+  try {
+    await plugin.inspect('.', path.join(testProjectPath, 'pom.xml'), {
+      reachableVulns: true,
+    });
+    t.fail('should not reach here, test should have failed');
+  } catch (err) {
+    t.ok(
+      javaCallGraphBuilderStub.calledOnce,
+      'called to the call graph builder',
+    );
+    t.ok(
+      javaCallGraphBuilderStub.calledWith(testProjectPath),
+      'call graph builder was called with the correct path',
+    );
+    t.equals(
+      err.message,
+      "Failed to scan for reachable vulns. Couldn't find the application entry point.",
+      'correct error message',
+    );
+    t.equals(
+      err.innerError.message,
+      'No entrypoints found',
+      'correct inner error',
+    );
+  }
+});
+
+test('inspect on test-project pom with reachable vulns', async (t) => {
+  const mavenCallGraph = await readFixtureJSON('call-graphs', 'simple.json');
+  const javaCallGraphBuilderStub = sinon
+    .stub(javaCallGraphBuilder, 'getCallGraphMvn')
+    .resolves(mavenCallGraph as CallGraph);
+  const result = await plugin.inspect(
+    '.',
+    path.join(testProjectPath, 'pom.xml'),
+    {
+      reachableVulns: true,
+    },
+  );
+  const expected = await readFixtureJSON(
+    'test-project',
+    'expected-with-call-graph.json',
+  );
+  t.ok(javaCallGraphBuilderStub.calledOnce, 'called to the call graph builder');
+  t.ok(
+    javaCallGraphBuilderStub.calledWith(testProjectPath),
+    'call graph builder was called with the correct path',
+  );
+  delete result.plugin.meta;
+  t.same(result, expected, 'should return expected result');
+  t.tearDown(() => {
+    javaCallGraphBuilderStub.restore();
+  });
+});

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -65,34 +65,6 @@ test('inspect on test-project pom with --dev', async (t) => {
   t.same(result, expected, 'should return expected result');
 });
 
-test('inspect on test-project pom with reachable vulns', async (t) => {
-  const mavenCallGraph = await readFixtureJSON('call-graphs', 'simple.json');
-  const javaCallGraphBuilderStub = sinon
-    .stub(javaCallGraphBuilder, 'getCallGraphMvn')
-    .resolves(mavenCallGraph as CallGraph);
-  const result = await plugin.inspect(
-    '.',
-    path.join(testProjectPath, 'pom.xml'),
-    {
-      reachableVulns: true,
-    },
-  );
-  const expected = await readFixtureJSON(
-    'test-project',
-    'expected-with-call-graph.json',
-  );
-  t.ok(javaCallGraphBuilderStub.calledOnce, 'called to the call graph builder');
-  t.ok(
-    javaCallGraphBuilderStub.calledWith(testProjectPath),
-    'call graph builder was called with the correct path',
-  );
-  delete result.plugin.meta;
-  t.same(result, expected, 'should return expected result');
-  t.tearDown(() => {
-    javaCallGraphBuilderStub.restore();
-  });
-});
-
 test('inspect on path with spaces pom', async (t) => {
   const result = await plugin.inspect(
     '.',


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Present more user-friendly messages for call graph errors
This relies on https://github.com/snyk/java-call-graph-builder/pull/11

Also, moved reachable vulns system tests to its own file.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-202

#### Screenshots
![image](https://user-images.githubusercontent.com/5316748/80311976-692f6700-87eb-11ea-973f-db728a65f4b9.png)


![image](https://user-images.githubusercontent.com/5316748/80311961-4b620200-87eb-11ea-9fb2-25261a9f8ce5.png)


#### Additional questions
