### PR TITLE
fix: use targetFilePath to execute callGraph generation

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,9 +102,7 @@ export async function inspect(
     if (options.reachableVulns) {
       debug(`getting call graph from path ${targetPath}`);
       try {
-        callGraph = await javaCallGraphBuilder.getCallGraphMvn(
-          path.dirname(targetPath),
-        );
+        callGraph = await javaCallGraphBuilder.getCallGraphMvn(targetFilePath);
         maybeCallGraphMetrics = {
           callGraphMetrics: javaCallGraphBuilder.runtimeMetrics(),
         };


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

the parameter `root` to `inspect` can be either a file path or a dir path. Executing
`dirname` on it can for the later case return the previous directory instead of project's directory.

#### How should this be manually tested?


