### PR TITLE
fix: bump java-call-graph-builder to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@snyk/cli-interface": "2.5.0",
-    "@snyk/java-call-graph-builder": "1.8.0",
+    "@snyk/java-call-graph-builder": "1.8.1",
     "debug": "^4.1.1",
     "needle": "^2.4.0",
     "tmp": "^0.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps java call graph builder to fix an issue with multiple nested target dirs.
https://github.com/snyk/java-call-graph-builder/pull/17

