### PR TITLE
fix: enable mvn plugging logging via cli

### DIFF
--- a/lib/jar.ts
+++ b/lib/jar.ts
@@ -38,22 +38,18 @@ function getSha1(buf: Buffer) {
 async function getMavenDependency(
   targetPath: string,
 ): Promise<MavenDependency> {
-  try {
-    const contents = fs.readFileSync(targetPath);
-    const sha1 = getSha1(contents);
-    const { g, a, v } = await getMavenPackageInfo(sha1, targetPath);
-    return {
-      groupId: g,
-      artifactId: a,
-      version: v,
-    };
-  } catch (err) {
-    throw err;
-  }
+  const contents = fs.readFileSync(targetPath);
+  const sha1 = getSha1(contents);
+  const { g, a, v } = await getMavenPackageInfo(sha1, targetPath);
+  return {
+    groupId: g,
+    artifactId: a,
+    version: v,
+  };
 }
 
 async function getDependencies(paths: string[]): Promise<MavenDependency[]> {
-  let dependencies: MavenDependency[] = [];
+  const dependencies: MavenDependency[] = [];
   for (const p of paths) {
     try {
       const dependency = await getMavenDependency(p);
@@ -73,6 +69,7 @@ export async function createPomForJar(
   const targetPath = path.resolve(root, targetFile);
   try {
     const dependency = await getMavenDependency(targetPath);
+    debug(`Creating pom.xml for ${JSON.stringify(dependency)}`);
     const rootDependency = getRootDependency(root, targetFile);
     const pomContents = getPomContents([dependency], rootDependency);
     const pomFile = createTempPomFile(targetPath, pomContents);
@@ -91,6 +88,7 @@ export async function createPomForJars(root: string): Promise<string> {
       .filter(isJar)
       .map((jar) => path.join(root, jar));
     const dependencies = await getDependencies(jarPaths);
+    debug(`Creating pom.xml for ${JSON.stringify(dependencies)}`);
     const rootDependency = getRootDependency(root);
     const pomContents = getPomContents(dependencies, rootDependency);
     const pomFile = createTempPomFile(root, pomContents);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Enable mvn plugin to log when running the cli with `DEBUG=snyk-mvn-plugin snyk monitor --scan-all-unmanaged -d` just like we do for gradle plugin

<img width="816" alt="Screen Shot 2020-05-12 at 23 14 32" src="https://user-images.githubusercontent.com/2911613/81752063-a6148280-94a8-11ea-996f-5411b92272fb.png">
