### PR TITLE
feat: upgrade needle (redirect bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@snyk/cli-interface": "2.5.0",
     "@snyk/java-call-graph-builder": "1.8.1",
     "debug": "^4.1.1",
-    "needle": "^2.4.0",
+    "needle": "^2.5.0",
     "tmp": "^0.1.0",
     "tslib": "1.11.1"
   }


### PR DESCRIPTION
needle has a bug with sockets on newer node 12,
we're currently avoiding this newer node 12 to
evade the problem. This bug is fixed in needle
2.5.0, so let's upgrade to that.

https://github.com/tomas/needle/issues/312
