### PR TITLE
fix: remove usage of shell in spawn processes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,8 +102,8 @@ export async function inspect(
       cwd: targetFilePath,
     });
     const versionResult = await subProcess.execute(
-      `${mavenCommand} --version`,
-      [],
+      `${mavenCommand}`,
+      ['--version'],
       {
         cwd: targetFilePath,
       },

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,10 +1,7 @@
 import * as childProcess from 'child_process';
 
 export function execute(command, args, options): Promise<string> {
-  const spawnOptions: {
-    shell: boolean;
-    cwd?: string;
-  } = { shell: true };
+  const spawnOptions: { cwd?: string } = {};
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }


### PR DESCRIPTION
#### What does this PR do?
Don't use the shell in spawned node processes.