### PR TITLE
fix: remove production env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,9 +153,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    environment:
-      NODE_ENV: "production"
-    resource_class: small
     steps:
       - checkout
       - install_deps


### PR DESCRIPTION
#### What does this PR do?
Remove `production` env var in order to install `devDeps`
