### PR TITLE
fix: Make generic Maven error message more useful

### DIFF
--- a/lib/error-format.ts
+++ b/lib/error-format.ts
@@ -9,8 +9,8 @@ export function formatGenericPluginError(
   return (
     error.message +
     '\n\n' +
-    'Please make sure that Apache Maven Dependency Plugin ' +
-    'version 2.2 or above is installed, and that `' +
+    'Please make sure that Maven ' +
+    'version 3.0.4 or above is installed, and that `' +
     fullCommand +
     '` executes successfully ' +
     'on this project.\n\n' +

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -220,8 +220,8 @@ test('inspect on mvn error', async (t) => {
   } catch (error) {
     const expectedCommand =
       '\n\n' +
-      'Please make sure that Apache Maven Dependency Plugin ' +
-      'version 2.2 or above is installed, and that `' +
+      'Please make sure that Maven ' +
+      'version 3.0.4 or above is installed, and that `' +
       fullCommand +
       '` executes successfully ' +
       'on this project.\n\n' +


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- Specifying the minimum Maven Dependency Plugin version was confusing and not very useful, so
- Specify the minimum Maven version instead

#### Additional info

Maven 3.0.4, are you sure?

No. I did my best using:

- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin
- https://maven.apache.org/docs/history.html
