### PR TITLE
feat: upgrade call graph builder to 1.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
-    "@snyk/java-call-graph-builder": "1.13.2",
+    "@snyk/java-call-graph-builder": "1.15.1",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?

Upgrades the call graph builder to v1.15.1, which among other things formats messages for maven and gradle environments as well as logging parts of the stack trace of the call graph generator.

#### Screenshots

![image](https://user-images.githubusercontent.com/11861490/95018116-3aed6780-0666-11eb-9461-e46729796c7a.png)

