### PR TITLE
fix: update java-call-graph-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
-    "@snyk/java-call-graph-builder": "1.16.1",
+    "@snyk/java-call-graph-builder": "1.16.2",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
Updates to the new snyk-config version that should get shipped with the CLI first.

Requirement for snyk/snyk#1524
Follow up to the snyk/config#43 and snyk/java-call-graph-builder#37