### PR TITLE
fix: use Java call graph builder with long path fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
-    "@snyk/java-call-graph-builder": "1.16.2",
+    "@snyk/java-call-graph-builder": "1.16.3",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Bumps the version of the java call graph builder to include the long path fix.

https://github.com/snyk/java-call-graph-builder/pull/38