### PR TITLE
fix: better error messages and newline handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@snyk/cli-interface": "2.9.1",
-    "@snyk/java-call-graph-builder": "1.16.4",
+    "@snyk/java-call-graph-builder": "1.16.5",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
bumps `java-call-graph-builder` to version `1.16.5`.

The new version of java-call-graph-builder introduces better error descriptions when executing maven commands and improved newline handling for different platforms.

#### How should this be manually tested?

Running `snyk test --reachable` in windows and Linux environments
