### PR TITLE
Use latest @snyk/cli-interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "tap-only": "0.0.5"
   },
   "dependencies": {
-    "@snyk/cli-interface": "2.9.1",
+    "@snyk/cli-interface": "2.11.0",
+    "@snyk/dep-graph": "^1.23.1",
     "@snyk/java-call-graph-builder": "1.19.1",
     "debug": "^4.1.1",
     "glob": "^7.1.6",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Uses the latest version of `@snyk/cli-interface` to reduce lodash exposure.

I also needed to add `@snyk/dep-graph` as a dependency since, in `@snyk/cli-interface` it was moved from `dependencies` to `peerDependencies` in here: https://github.com/snyk/snyk-cli-interface/pull/42/files

#### Any background context you want to provide?
https://snyk.slack.com/archives/C01MDU3UL59
