### PR TITLE
feat: update java-call-graph-builder version.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -166,6 +166,7 @@ export async function inspect(
       callGraph = await getCallGraph(
         targetPath,
         timeout, // expects ms
+        options.args,
       );
       maybeCallGraphMetrics = {
         callGraphMetrics: javaCallGraphBuilder.runtimeMetrics(),
@@ -221,12 +222,14 @@ export function buildArgs(
 async function getCallGraph(
   targetPath: string,
   timeout?: number,
+  customMavenArgs?: string[],
 ): Promise<CallGraphResult> {
   debug(`getting call graph from path ${targetPath}`);
   try {
     const callGraph: CallGraph = await javaCallGraphBuilder.getCallGraphMvn(
       path.dirname(targetPath),
       timeout,
+      customMavenArgs,
     );
     debug('got call graph successfully');
     return callGraph;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.23.1",
-    "@snyk/java-call-graph-builder": "1.19.1",
+    "@snyk/java-call-graph-builder": "1.21.0",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",

--- a/tests/fixtures/test-project/settings.xml
+++ b/tests/fixtures/test-project/settings.xml
@@ -1,0 +1,12 @@
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <localRepository/>
+      <interactiveMode/>
+      <offline/>
+      <pluginGroups/>
+      <servers/>
+      <mirrors/>
+      <proxies/>
+      <profiles/>
+      <activeProfiles/>
+    </settings>


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Calling call graph maven with option.args so that the arguments will be propagated to the maven module of the call graph builder. Update the version of java-call-graph-builder to the latest one.