### PR TITLE
fix: use classifier in package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ __pycache__/
 package-lock.json
 npm-debug.log
 .eslintcache
-/.vscode
 .idea
 
 # Diagnostic reports (https://nodejs.org/api/report.html)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Tap Current File",
+      "console": "integratedTerminal",
+      "program": "${workspaceFolder}/node_modules/.bin/ts-node",
+      "args": ["${workspaceFolder}/${relativeFile}"]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "semantic-release": "^15",
     "sinon": "^2.4.1",
     "tap": "^12.0.1",
-    "tap-only": "0.0.5"
+    "tap-only": "0.0.5",
+    "ts-node": "^8.10.2"
   },
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",

--- a/tests/fixtures/duplicate-dep-with-classifier/pom.xml
+++ b/tests/fixtures/duplicate-dep-with-classifier/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <version>2.2.0.RELEASE</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/fixtures/parse-mvn/duplicate-dep-with-classifier-results.json
+++ b/tests/fixtures/parse-mvn/duplicate-dep-with-classifier-results.json
@@ -1,0 +1,176 @@
+{
+  "name": "com.mycompany.app:my-app",
+  "version": "1.0-SNAPSHOT",
+  "dependencies": {
+    "org.springframework.kafka:spring-kafka-test": {
+      "dependencies": {
+        "org.springframework:spring-context": {
+          "dependencies": {
+            "org.springframework:spring-aop": {
+              "dependencies": {},
+              "version": "5.1.2.RELEASE",
+              "name": "org.springframework:spring-aop",
+              "labels": { "scope": "compile" }
+            },
+            "org.springframework:spring-beans": {
+              "dependencies": {},
+              "version": "5.1.2.RELEASE",
+              "name": "org.springframework:spring-beans",
+              "labels": { "scope": "compile" }
+            },
+            "org.springframework:spring-core": {
+              "dependencies": {
+                "org.springframework:spring-jcl": {
+                  "dependencies": {},
+                  "version": "5.1.2.RELEASE",
+                  "name": "org.springframework:spring-jcl",
+                  "labels": { "scope": "compile" }
+                }
+              },
+              "version": "5.1.2.RELEASE",
+              "name": "org.springframework:spring-core",
+              "labels": { "scope": "compile" }
+            },
+            "org.springframework:spring-expression": {
+              "dependencies": {},
+              "version": "5.1.2.RELEASE",
+              "name": "org.springframework:spring-expression",
+              "labels": { "scope": "compile" }
+            }
+          },
+          "version": "5.1.2.RELEASE",
+          "name": "org.springframework:spring-context",
+          "labels": { "scope": "compile" }
+        },
+        "org.springframework:spring-test": {
+          "dependencies": {},
+          "version": "5.1.2.RELEASE",
+          "name": "org.springframework:spring-test",
+          "labels": { "scope": "compile" }
+        },
+        "org.springframework.retry:spring-retry": {
+          "dependencies": {},
+          "version": "1.2.2.RELEASE",
+          "name": "org.springframework.retry:spring-retry",
+          "labels": { "scope": "compile" }
+        },
+        "org.apache.kafka:kafka-clients:test": {
+          "dependencies": {
+            "org.lz4:lz4-java": {
+              "dependencies": {},
+              "version": "1.4.1",
+              "name": "org.lz4:lz4-java",
+              "labels": { "scope": "compile" }
+            },
+            "org.xerial.snappy:snappy-java": {
+              "dependencies": {},
+              "version": "1.1.7.1",
+              "name": "org.xerial.snappy:snappy-java",
+              "labels": { "scope": "compile" }
+            },
+            "org.slf4j:slf4j-api": {
+              "dependencies": {},
+              "version": "1.7.25",
+              "name": "org.slf4j:slf4j-api",
+              "labels": { "scope": "compile" }
+            }
+          },
+          "version": "2.0.0",
+          "name": "org.apache.kafka:kafka-clients:test",
+          "labels": { "scope": "compile" }
+        },
+        "org.apache.kafka:kafka_2.11": {
+          "dependencies": {
+            "org.apache.kafka:kafka-clients": {
+              "dependencies": {},
+              "version": "2.0.0",
+              "name": "org.apache.kafka:kafka-clients",
+              "labels": { "scope": "compile" }
+            },
+            "com.fasterxml.jackson.core:jackson-databind": {
+              "dependencies": {
+                "com.fasterxml.jackson.core:jackson-annotations": {
+                  "dependencies": {},
+                  "version": "2.9.0",
+                  "name": "com.fasterxml.jackson.core:jackson-annotations",
+                  "labels": { "scope": "compile" }
+                },
+                "com.fasterxml.jackson.core:jackson-core": {
+                  "dependencies": {},
+                  "version": "2.9.6",
+                  "name": "com.fasterxml.jackson.core:jackson-core",
+                  "labels": { "scope": "compile" }
+                }
+              },
+              "version": "2.9.6",
+              "name": "com.fasterxml.jackson.core:jackson-databind",
+              "labels": { "scope": "compile" }
+            },
+            "net.sf.jopt-simple:jopt-simple": {
+              "dependencies": {},
+              "version": "5.0.4",
+              "name": "net.sf.jopt-simple:jopt-simple",
+              "labels": { "scope": "compile" }
+            },
+            "com.yammer.metrics:metrics-core": {
+              "dependencies": {},
+              "version": "2.2.0",
+              "name": "com.yammer.metrics:metrics-core",
+              "labels": { "scope": "compile" }
+            },
+            "org.scala-lang:scala-library": {
+              "dependencies": {},
+              "version": "2.11.12",
+              "name": "org.scala-lang:scala-library",
+              "labels": { "scope": "compile" }
+            },
+            "org.scala-lang:scala-reflect": {
+              "dependencies": {},
+              "version": "2.11.12",
+              "name": "org.scala-lang:scala-reflect",
+              "labels": { "scope": "compile" }
+            },
+            "com.typesafe.scala-logging:scala-logging_2.11": {
+              "dependencies": {},
+              "version": "3.9.0",
+              "name": "com.typesafe.scala-logging:scala-logging_2.11",
+              "labels": { "scope": "compile" }
+            },
+            "com.101tec:zkclient": {
+              "dependencies": {},
+              "version": "0.10",
+              "name": "com.101tec:zkclient",
+              "labels": { "scope": "compile" }
+            },
+            "org.apache.zookeeper:zookeeper": {
+              "dependencies": {
+                "org.apache.yetus:audience-annotations": {
+                  "dependencies": {},
+                  "version": "0.5.0",
+                  "name": "org.apache.yetus:audience-annotations",
+                  "labels": { "scope": "compile" }
+                }
+              },
+              "version": "3.4.13",
+              "name": "org.apache.zookeeper:zookeeper",
+              "labels": { "scope": "compile" }
+            }
+          },
+          "version": "2.0.0",
+          "name": "org.apache.kafka:kafka_2.11",
+          "labels": { "scope": "compile" }
+        },
+        "org.apache.kafka:kafka_2.11:test": {
+          "dependencies": {},
+          "version": "2.0.0",
+          "name": "org.apache.kafka:kafka_2.11:test",
+          "labels": { "scope": "compile" }
+        }
+      },
+      "version": "2.2.0.RELEASE",
+      "name": "org.springframework.kafka:spring-kafka-test",
+      "labels": { "scope": "compile" }
+    }
+  },
+  "packageFormatVersion": "mvn:0.0.1"
+}

--- a/tests/fixtures/parse-mvn/duplicate-dep-with-classifier.txt
+++ b/tests/fixtures/parse-mvn/duplicate-dep-with-classifier.txt
@@ -1,0 +1,42 @@
+[INFO] Scanning for projects...
+[INFO] 
+[INFO] ----------------------< com.mycompany.app:my-app >----------------------
+[INFO] Building my-app 1.0-SNAPSHOT
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ my-app ---
+[INFO] digraph "com.mycompany.app:my-app:jar:1.0-SNAPSHOT" { 
+[INFO] 	"com.mycompany.app:my-app:jar:1.0-SNAPSHOT" -> "org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" ; 
+[INFO] 	"org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" -> "org.springframework:spring-context:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" -> "org.springframework:spring-test:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" -> "org.springframework.retry:spring-retry:jar:1.2.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" -> "org.apache.kafka:kafka-clients:jar:test:2.0.0:compile" ; 
+[INFO] 	"org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" -> "org.apache.kafka:kafka_2.11:jar:2.0.0:compile" ; 
+[INFO] 	"org.springframework.kafka:spring-kafka-test:jar:2.2.0.RELEASE:compile" -> "org.apache.kafka:kafka_2.11:jar:test:2.0.0:compile" ; 
+[INFO] 	"org.springframework:spring-context:jar:5.1.2.RELEASE:compile" -> "org.springframework:spring-aop:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework:spring-context:jar:5.1.2.RELEASE:compile" -> "org.springframework:spring-beans:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework:spring-context:jar:5.1.2.RELEASE:compile" -> "org.springframework:spring-core:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework:spring-context:jar:5.1.2.RELEASE:compile" -> "org.springframework:spring-expression:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.springframework:spring-core:jar:5.1.2.RELEASE:compile" -> "org.springframework:spring-jcl:jar:5.1.2.RELEASE:compile" ; 
+[INFO] 	"org.apache.kafka:kafka-clients:jar:test:2.0.0:compile" -> "org.lz4:lz4-java:jar:1.4.1:compile" ; 
+[INFO] 	"org.apache.kafka:kafka-clients:jar:test:2.0.0:compile" -> "org.xerial.snappy:snappy-java:jar:1.1.7.1:compile" ; 
+[INFO] 	"org.apache.kafka:kafka-clients:jar:test:2.0.0:compile" -> "org.slf4j:slf4j-api:jar:1.7.25:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "org.apache.kafka:kafka-clients:jar:2.0.0:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "net.sf.jopt-simple:jopt-simple:jar:5.0.4:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "com.yammer.metrics:metrics-core:jar:2.2.0:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "org.scala-lang:scala-library:jar:2.11.12:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "org.scala-lang:scala-reflect:jar:2.11.12:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "com.typesafe.scala-logging:scala-logging_2.11:jar:3.9.0:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "com.101tec:zkclient:jar:0.10:compile" ; 
+[INFO] 	"org.apache.kafka:kafka_2.11:jar:2.0.0:compile" -> "org.apache.zookeeper:zookeeper:jar:3.4.13:compile" ; 
+[INFO] 	"com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile" -> "com.fasterxml.jackson.core:jackson-annotations:jar:2.9.0:compile" ; 
+[INFO] 	"com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile" -> "com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile" ; 
+[INFO] 	"org.apache.zookeeper:zookeeper:jar:3.4.13:compile" -> "org.apache.yetus:audience-annotations:jar:0.5.0:compile" ; 
+[INFO]  } 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  1.011 s
+[INFO] Finished at: 2021-06-10T11:37:21+01:00
+[INFO] ------------------------------------------------------------------------

--- a/tests/functional/parse-mvn.test.ts
+++ b/tests/functional/parse-mvn.test.ts
@@ -22,6 +22,17 @@ test('parseTree with --dev', async (t) => {
   t.same(depTree.data, results, 'should return expected results');
 });
 
+test('parseTree given duplicate dep with classifier', async (t) => {
+  const mavenOutput = await readFixture(
+    'parse-mvn/duplicate-dep-with-classifier.txt',
+  );
+  const depTree = parseTree(mavenOutput, false);
+  const results = await readFixtureJSON(
+    'parse-mvn/duplicate-dep-with-classifier-results.json',
+  );
+  t.same(depTree.data, results, 'should return expected results');
+});
+
 test('parseTree with bad mvn dependency:tree output', async (t) => {
   const mavenOutput = await readFixture(
     'parse-mvn/maven-dependency-tree-bad.txt',


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?

When two dependencies with the same groupId and artifiactId appear in the dep tree, but they have a different classifier we should treat them as different nodes in the tree. At the moment we overwrite these nodes, which can lead to incorrect results form snyk test.
