### PR TITLE
fix: update java-call-graph-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.23.1",
-    "@snyk/java-call-graph-builder": "1.21.0",
+    "@snyk/java-call-graph-builder": "1.23.1",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
https://github.com/snyk/java-call-graph-builder/pull/54

Update java-call-graph-builder to the version that uses version 3.7 of JSZip in order to mitigate a vulnerability