### PR TITLE
fix: Update java-call-graph-builder to circumvent log4j vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.23.1",
-    "@snyk/java-call-graph-builder": "1.23.1",
+    "@snyk/java-call-graph-builder": "1.23.3",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
Update java-call-graph-builder to circumvent log4j vuln
