### PR TITLE
fix: bump java-call-graph-builder to 1.23.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.0",
     "@snyk/dep-graph": "^1.23.1",
-    "@snyk/java-call-graph-builder": "1.23.3",
+    "@snyk/java-call-graph-builder": "1.23.6",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
     "needle": "^2.5.0",


### PR DESCRIPTION
#### What does this PR do?
This is in order to mitigate [CVE-2021-45105](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)