### PR TITLE
fix: scan aggregate root poms

### DIFF
--- a/lib/parse-mvn.ts
+++ b/lib/parse-mvn.ts
@@ -51,17 +51,6 @@ function getRootProject(text, withDev) {
     ...rootProject,
   };
 
-  // Add any subsequent projects to the root as dependencies
-  for (let i = 1; i < projects.length; i++) {
-    const project: legacyCommon.DepTree | null = getProject(
-      projects[i],
-      withDev,
-    );
-    if (project && project.name) {
-      root.dependencies = {};
-      root.dependencies[project.name] = project;
-    }
-  }
   return root;
 }
 

--- a/tests/fixtures/aggregate-project/module-a/pom.xml
+++ b/tests/fixtures/aggregate-project/module-a/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.snyk</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.2.3</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>module-a</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.6.2</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/tests/fixtures/aggregate-project/pom.xml
+++ b/tests/fixtures/aggregate-project/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.2.3</version>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module-a</module>
+  </modules>
+
+</project>

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -1,10 +1,6 @@
 import * as path from 'path';
 import * as test from 'tap-only';
-import * as sinon from 'sinon';
-import * as javaCallGraphBuilder from '@snyk/java-call-graph-builder';
 import { legacyPlugin } from '@snyk/cli-interface';
-import { CallGraph } from '@snyk/cli-interface/legacy/common';
-import * as os from 'os';
 
 import * as plugin from '../../lib';
 import { readFixtureJSON } from '../file-helper';
@@ -320,4 +316,25 @@ test('inspect on mvnw successful when resides in parent directory with targetFil
   // therefore, only independent objects are compared
   delete result.plugin.meta;
   t.same(result, expected, 'should return expected result');
+});
+
+test('inspect on aggregate project root pom', async (t) => {
+  const result = await plugin.inspect(
+    path.join(fixturesPath, 'aggregate-project'),
+    'pom.xml',
+  );
+  if (legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected single inspect result');
+  }
+  t.same(
+    result.package,
+    {
+      // root pom has no dependencies
+      dependencies: {},
+      name: 'io.snyk:my-app',
+      packageFormatVersion: 'mvn:0.0.1',
+      version: '1.2.3',
+    },
+    'should return expected result',
+  );
 });


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
The CLI now supports --all-projects to scan each pom file.
Aggregate projects (modules) should not be considered dependencies of the
root project.

This brings the CLI closer to Snyk git scanning, where we treat each pom
file as a separate project.
