### PR TITLE
fix: add option to provide own depTreeFile, instead of running the mavencommand to generate it.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import * as javaCallGraphBuilder from '@snyk/java-call-graph-builder';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
+import { readFile } from '../tests/file-helper';
 
 import { parseTree, parseVersions } from './parse-mvn';
 import * as subProcess from './sub-process';
@@ -38,6 +39,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   reachableVulns?: boolean;
   callGraphBuilderTimeout?: number;
   allProjects?: boolean;
+  depTreeFile?: string;
 }
 
 export function getCommand(root: string, targetFile: string | undefined) {
@@ -161,9 +163,11 @@ export async function inspect(
     options.args,
   );
   try {
-    const result = await subProcess.execute(mavenCommand, mvnArgs, {
-      cwd: mvnWorkingDirectory,
-    });
+    const result = await (options.depTreeFile
+      ? readFile(options.depTreeFile)
+      : subProcess.execute(mavenCommand, mvnArgs, {
+          cwd: mvnWorkingDirectory,
+        }));
     const versionResult = await subProcess.execute(
       `${mavenCommand} --version`,
       [],


### PR DESCRIPTION

- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add support for optional `depTreeFile` option for mvn cli. If present, the plugin will skip calling `mvn dependency:tree` and use the contents of the file as input to create the dependency graph object needed for the Snyk API request.


#### Where should the reviewer start?
lib/index.ts


#### How should this be manually tested?


#### Any background context you want to provide?
Since `mvn dependency:tree` does not use the maven reactor by default, it's output does not provide an accurate output for multi module projects. By allowing a dep tree file to be passed in, it will allow users to run `mvn dependency:tree` with their own settings and specify to snyk which dependency tree to look at when analyzing dependencies and scanning for vulnerabilities.


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
