### PR TITLE
fix: throw maven subprocess stderr over stdout if process fails

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -23,7 +23,7 @@ export function execute(command, args, options): Promise<string> {
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        return reject(new Error(stdout || stderr));
+        return reject(new Error(stderr || stdout));
       }
       resolve(stdout || stderr);
     });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When the mvn subprocess completes with a code that isn't 0, we were throwing the stdout over stderr, which meant that partially complete output would be seen in debug logs instead of the helpful error log. This PR swaps the order of importance so that stderr is thrown if it exists and falls back on stdout if not.

#### What are the relevant tickets?
[TARDIS-808](https://snyksec.atlassian.net/browse/TARDIS-808)