### PR TITLE
fix: add mvn command debug logs

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -162,6 +162,8 @@ export async function inspect(
   );
   let result;
   try {
+    debug(`Maven command: ${mavenCommand} ${mvnArgs.join(' ')}`);
+    debug(`Maven working directory: ${mvnWorkingDirectory}`);
     result = await subProcess.execute(mavenCommand, mvnArgs, {
       cwd: mvnWorkingDirectory,
     });


### PR DESCRIPTION
To help us better diagnose issues with snyk-mvn-plugin, add more debug logs that show what command is being run, which args are being used and in what directory.