### PR TITLE
fix: non recursive output on aggregate projects

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -226,7 +226,12 @@ export function buildArgs(
   mavenArgs?: string[] | undefined,
 ) {
   // Requires Maven >= 2.2
-  let args = ['dependency:tree', '-DoutputType=dot', '--batch-mode'];
+  let args = [
+    'dependency:tree', // use dependency plugin to display a tree of dependencies
+    '-DoutputType=dot', // use 'dot' output format
+    '--batch-mode', // clean up output, disables output color and download progress
+    '--non-recursive', // do not include sub modules these are handled by separate scans using --all-projects
+  ];
   if (targetFile) {
     // if we are where we can execute - we preserve the original path;
     // if not - we rely on the executor (mvnw) to be spawned at the closest directory, leaving us w/ the file itself

--- a/tests/functional/mvn-plugin.test.ts
+++ b/tests/functional/mvn-plugin.test.ts
@@ -9,6 +9,7 @@ test('buildArgs with array', async (t) => {
       'dependency:tree',
       '-DoutputType=dot',
       '--batch-mode',
+      '--non-recursive',
       '-Paxis',
       '-Pjaxen',
     ],

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -207,7 +207,7 @@ test('inspect on pom with bad dependency', async (t) => {
 
 test('inspect on mvn error', async (t) => {
   const targetFile = path.join(fixturesPath, 'bad', 'pom.xml');
-  const fullCommand = `mvn dependency:tree -DoutputType=dot --batch-mode --file="${targetFile}"`;
+  const fullCommand = `mvn dependency:tree -DoutputType=dot --batch-mode --non-recursive --file="${targetFile}"`;
   try {
     await plugin.inspect('.', targetFile, {
       dev: true,


### PR DESCRIPTION
The Maven Reactor doesn't guarantee the order of projects output using 'mvn dependency:tree' when listing dependencies in a nested aggregated project.

Sometimes a sub-module can appear first in the list of digraphs. The parsing code assumes the first digraph output is the project under test.

Using the Maven CLI option '--non-recursive' removes any noise from sub-modules from 'mvn dependency:tree' output.

Snyk aggregate project scans rely on the Snyk CLI arg --all-projects, which scan each pom.xml separately, so we never what to output and parse sub-modules.