### PR TITLE
fix: package manager name scanning unmanaged

### DIFF
--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -96,7 +96,7 @@ export async function createDepGraphFromArchives(
       name: `${rootDependency.groupId}:${rootDependency.artifactId}`,
       version: rootDependency.version,
     };
-    const builder = new DepGraphBuilder({ name: ' maven' }, rootPkg);
+    const builder = new DepGraphBuilder({ name: 'maven' }, rootPkg);
     for (const dependency of dependencies) {
       const nodeId = `${dependency.groupId}:${dependency.artifactId}@${dependency.version}`;
       builder.addPkgNode(

--- a/tests/fixtures/aar/dep-graph.json
+++ b/tests/fixtures/aar/dep-graph.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.2.0",
-  "pkgManager": { "name": " maven" },
+  "pkgManager": { "name": "maven" },
   "pkgs": [
     {
       "id": "fixtures:aar@1.0.0",

--- a/tests/fixtures/good-and-bad/dep-graph.json
+++ b/tests/fixtures/good-and-bad/dep-graph.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.2.0",
-  "pkgManager": { "name": " maven" },
+  "pkgManager": { "name": "maven" },
   "pkgs": [
     {
       "id": "fixtures:good-and-bad@1.0.0",

--- a/tests/fixtures/jar-wrong-package-name/dep-graph.json
+++ b/tests/fixtures/jar-wrong-package-name/dep-graph.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.2.0",
-  "pkgManager": { "name": " maven" },
+  "pkgManager": { "name": "maven" },
   "pkgs": [
     {
       "id": "fixtures:jar-wrong-package-name@1.0.0",

--- a/tests/fixtures/jars/dep-graph.json
+++ b/tests/fixtures/jars/dep-graph.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.2.0",
-  "pkgManager": { "name": " maven" },
+  "pkgManager": { "name": "maven" },
   "pkgs": [
     {
       "id": "fixtures:jars@1.0.0",

--- a/tests/fixtures/nested-jars/dep-graph.json
+++ b/tests/fixtures/nested-jars/dep-graph.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.2.0",
-  "pkgManager": { "name": " maven" },
+  "pkgManager": { "name": "maven" },
   "pkgs": [
     {
       "id": "fixtures:nested-jars@1.0.0",

--- a/tests/fixtures/spring-core/dep-graph.json
+++ b/tests/fixtures/spring-core/dep-graph.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.2.0",
   "pkgManager": {
-    "name": " maven"
+    "name": "maven"
   },
   "pkgs": [
     {


### PR DESCRIPTION
Introduced by https://github.com/snyk/snyk-mvn-plugin/pull/115

Package manager should be 'maven' not ' maven' (remove space).