### PR TITLE
feat: improve sub-process debug logging

### DIFF
--- a/lib/error-format.ts
+++ b/lib/error-format.ts
@@ -16,6 +16,7 @@ export function formatGenericPluginError(
     'on this project.\n\n' +
     (mavenCommand.indexOf('mvnw') >= 0 ? mvnwCommandTipMessage : '') +
     'If the problem persists, collect the output of `' +
+    'DEBUG=* ' +
     fullCommand +
     '` and contact support@snyk.io\n'
   );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,7 +21,7 @@ const WRAPPERS = ['mvnw', 'mvnw.cmd'];
 // To enable debugging output, use `snyk -d`
 let logger: debugModule.Debugger | null = null;
 
-export function debug(s: string) {
+export function debug(...messages: string[]) {
   if (logger === null) {
     // Lazy init: Snyk CLI needs to process the CLI argument "-d" first.
     // TODO(BST-648): more robust handling of the debug settings
@@ -30,7 +30,7 @@ export function debug(s: string) {
     }
     logger = debugModule('snyk-mvn-plugin');
   }
-  logger(s);
+  messages.forEach((m) => logger(m));
 }
 
 export interface MavenOptions extends legacyPlugin.BaseInspectOptions {

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -32,7 +32,30 @@ export function execute(command, args, options): Promise<string> {
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        return reject(new Error(stderr || stdout));
+        debug(
+          `Child process failed with exit code: ${code}`,
+          '----------------',
+          'STDERR:',
+          stderr,
+          '----------------',
+          'STDOUT:',
+          stdout,
+          '----------------',
+        );
+
+        const stdErrMessage = stderr ? `\nSTDERR:\n${stderr}` : '';
+        const stdOutMessage = stdout ? `\nSTDOUT:\n${stdout}` : '';
+        const debugSuggestion = process.env.DEBUG
+          ? ''
+          : `\nRun in debug mode (-d) to see STDERR and STDOUT.`;
+
+        return reject(
+          new Error(
+            `Child process failed with exit code: ${code}.` +
+              debugSuggestion +
+              (stdErrMessage || stdOutMessage),
+          ),
+        );
       }
       resolve(stdout || stderr);
     });

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -158,7 +158,7 @@ test('inspect on root that does not contain a pom.xml and no target file', async
     if (err instanceof Error) {
       t.match(
         err.message,
-        'BUILD FAILURE',
+        'Child process failed with exit code: 1.',
         'should throw expected error with build failure message',
       );
       t.match(
@@ -235,6 +235,7 @@ test('inspect on mvn error', async (t) => {
         '` executes successfully ' +
         'on this project.\n\n' +
         'If the problem persists, collect the output of `' +
+        'DEBUG=* ' +
         fullCommand +
         '` and contact support@snyk.io\n';
       t.match(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds additional debug logs to the sub-process's "exit" event handler when the exit code isn't 0. The debug logs include all stdout and stderr up until that point, as well as the exit code.
Also added the `DEBUG=*` env variable to the suggested debug command.