### PR TITLE
refactor: parse digraph output

### DIFF
--- a/lib/parse/digraph.ts
+++ b/lib/parse/digraph.ts
@@ -1,0 +1,48 @@
+import type { MavenGraph } from './types';
+import { MavenGraphBuilder } from './maven-graph-builder';
+
+const newLine = /[\r\n]+/g;
+
+export function parseDigraphs(digraphs: string[]): MavenGraph[] {
+  const graphs: MavenGraph[] = [];
+  for (const digraph of digraphs) {
+    const lines = digraph.split(newLine);
+    const rootId = findQuotedContents(lines[0]);
+    if (!rootId) {
+      throw new Error(
+        `Unexpected digraph could not find root node. Could not parse "${lines[0]}".`,
+      );
+    }
+    const builder = new MavenGraphBuilder(rootId);
+    for (let i = 1; i < lines.length - 1; i++) {
+      const line = parseLine(lines[i]);
+      if (!line) {
+        throw new Error(
+          `Unexpected digraph could not connect nodes. Could not parse "${lines[i]}".`,
+        );
+      }
+      builder.connect(line.from, line.to);
+    }
+    graphs.push(builder.graph);
+  }
+  return graphs;
+}
+
+type ParsedLine = { from: string; to: string };
+
+function parseLine(line?: string): ParsedLine | null {
+  if (!line) return null;
+  const [left, right] = line.split('->');
+  if (!left || !right) return null;
+  const from = findQuotedContents(left);
+  const to = findQuotedContents(right);
+  if (!from || !to) return null;
+  return { from, to };
+}
+
+function findQuotedContents(value?: string): string | null {
+  if (!value) return null;
+  const start = value.indexOf('"') + 1;
+  const end = value.lastIndexOf('"');
+  return value.substring(start, end);
+}

--- a/lib/parse/maven-graph-builder.ts
+++ b/lib/parse/maven-graph-builder.ts
@@ -1,0 +1,38 @@
+import type { MavenGraph, MavenGraphNode } from './types';
+
+export class MavenGraphBuilder {
+  readonly #graph: MavenGraph;
+
+  constructor(rootId: string) {
+    this.#graph = {
+      rootId,
+      nodes: {
+        [rootId]: { dependsOn: [] },
+      },
+    };
+  }
+
+  private add(id: string): void {
+    if (!this.node(id)) {
+      this.#graph.nodes[id] = { dependsOn: [] };
+    }
+  }
+
+  private node(id: string): MavenGraphNode | undefined {
+    return this.#graph.nodes[id];
+  }
+
+  connect(parentId: string, id: string) {
+    this.add(parentId);
+    this.add(id);
+    const node = this.node(parentId);
+    if (!node) return;
+    if (!node.dependsOn.includes(id)) {
+      node.dependsOn.push(id);
+    }
+  }
+
+  get graph(): MavenGraph {
+    return this.#graph;
+  }
+}

--- a/lib/parse/types.ts
+++ b/lib/parse/types.ts
@@ -6,3 +6,12 @@ export interface MavenDependency {
   classifier?: string;
   scope?: string;
 }
+
+export interface MavenGraph {
+  rootId: string;
+  nodes: Record<string, MavenGraphNode>;
+}
+
+export interface MavenGraphNode {
+  dependsOn: string[];
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:eslint": "eslint --color --cache 'lib/**/*.{js,ts}'",
     "prepare": "npm run build",
     "test": "npm run prepare && npm run test:functional && npm run test:system",
-    "test:functional": "tap -R spec ./tests/functional/*.test.ts",
+    "test:functional": "tap -R spec ./tests/functional/**/*.test.ts",
     "test:system": "tap -R spec --timeout=180 ./tests/system/*.test.ts",
     "semantic-release": "semantic-release"
   },

--- a/tests/functional/parse/digraph.test.ts
+++ b/tests/functional/parse/digraph.test.ts
@@ -1,0 +1,75 @@
+import { test } from 'tap';
+import { parseDigraphs } from '../../../lib/parse/digraph';
+
+const core = `digraph "io.snyk:core:jar:1.0.0" { 
+"io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ; 
+"io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ; 
+}`;
+
+test('parses digraph', async (t) => {
+  t.same(
+    parseDigraphs([core]),
+    [
+      {
+        rootId: 'io.snyk:core:jar:1.0.0',
+        nodes: {
+          'io.snyk:core:jar:1.0.0': {
+            dependsOn: [
+              'org.apache.logging.log4j:log4j-api:jar:2.17.2:compile',
+              'org.apache.logging.log4j:log4j-core:jar:2.17.2:compile',
+            ],
+          },
+          'org.apache.logging.log4j:log4j-api:jar:2.17.2:compile': {
+            dependsOn: [],
+          },
+          'org.apache.logging.log4j:log4j-core:jar:2.17.2:compile': {
+            dependsOn: [],
+          },
+        },
+      },
+    ],
+    'contains expected graph',
+  );
+});
+
+const badRoot = `digraph bad { 
+  "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ; 
+  "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ; 
+}`;
+test('could not find root node', async (t) => {
+  try {
+    parseDigraphs([badRoot]);
+    t.fail('expected error to be thrown');
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      t.match(
+        err.message,
+        'Unexpected digraph could not find root node',
+        'throws expected error',
+      );
+    } else {
+      t.fail('expected err to be instanceof Error');
+    }
+  }
+});
+
+const badDependency = `digraph "io.snyk:core:jar:1.0.0" { 
+bad
+}`;
+
+test('could not connect nodes', async (t) => {
+  try {
+    parseDigraphs([badDependency]);
+    t.fail('expected error to be thrown');
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      t.match(
+        err.message,
+        'Unexpected digraph could not connect nodes',
+        'throws expected error',
+      );
+    } else {
+      t.fail('expected err to be instanceof Error');
+    }
+  }
+});

--- a/tests/functional/parse/maven-graph-builder.test.ts
+++ b/tests/functional/parse/maven-graph-builder.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'tap';
+import { MavenGraphBuilder } from '../../../lib/parse/maven-graph-builder';
+
+test('default constructor', async (t) => {
+  const builder = new MavenGraphBuilder('root');
+  t.same(
+    builder.graph,
+    {
+      rootId: 'root',
+      nodes: {
+        root: {
+          dependsOn: [],
+        },
+      },
+    },
+    'builds empty graph',
+  );
+});
+
+test('connect nodes', async (t) => {
+  const builder = new MavenGraphBuilder('root');
+  builder.connect('root', 'a');
+  builder.connect('a', 'b');
+  t.same(
+    builder.graph,
+    {
+      rootId: 'root',
+      nodes: {
+        root: {
+          dependsOn: ['a'],
+        },
+        a: {
+          dependsOn: ['b'],
+        },
+        b: {
+          dependsOn: [],
+        },
+      },
+    },
+    'builds connected graph',
+  );
+});
+
+test('skips duplicate connections', async (t) => {
+  const builder = new MavenGraphBuilder('root');
+  builder.connect('root', 'a');
+  builder.connect('root', 'a');
+  builder.connect('root', 'a');
+  t.same(
+    builder.graph,
+    {
+      rootId: 'root',
+      nodes: {
+        root: {
+          dependsOn: ['a'],
+        },
+        a: {
+          dependsOn: [],
+        },
+      },
+    },
+    'builds expected graph',
+  );
+});


### PR DESCRIPTION
Implement new functions and class to parse maven digraph output.

Introduces new interface 'MavenGraph' and class 'MavenGraphBuilder'.
To better capture the text being parsed.
We construct a 'MavenGraph' which captures each node and what it dependsOn.
This will be converted to a Snyk dep-graph in later PRs.

Tests document the boundaries between functions and modules.