### PR TITLE
feat: maven aggregate project option

### DIFF
--- a/lib/parse-mvn.ts
+++ b/lib/parse-mvn.ts
@@ -19,7 +19,7 @@ export function parseTree(text: string, withDev) {
   // extract deps
   const data = getRootProject(text, withDev);
 
-  return { ok: true, data };
+  return { package: data };
 }
 
 export function parseVersions(text: string): {

--- a/lib/parse/index.ts
+++ b/lib/parse/index.ts
@@ -1,0 +1,18 @@
+import type { ScannedProject } from '@snyk/cli-interface/legacy/common';
+
+import { parseStdout } from './stdout';
+import { parseDigraphs } from './digraph';
+import { buildDepGraph } from './dep-graph';
+
+export function parse(stdout: string): { scannedProjects: ScannedProject[] } {
+  const digraphs = parseStdout(stdout);
+  const mavenGraphs = parseDigraphs(digraphs);
+  const scannedProjects: ScannedProject[] = [];
+  for (const mavenGraph of mavenGraphs) {
+    const depGraph = buildDepGraph(mavenGraph);
+    scannedProjects.push({ depGraph });
+  }
+  return {
+    scannedProjects,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:eslint": "eslint --color --cache 'lib/**/*.{js,ts}'",
     "prepare": "npm run build",
     "test": "npm run prepare && npm run test:functional && npm run test:system",
-    "test:functional": "tap -R spec ./tests/functional/**/*.test.ts",
+    "test:functional": "tap -R spec ./tests/functional/*.test.ts",
     "test:system": "tap -R spec --timeout=180 ./tests/system/*.test.ts",
     "semantic-release": "semantic-release"
   },

--- a/tests/fixtures/complex-aggregate-project/README.md
+++ b/tests/fixtures/complex-aggregate-project/README.md
@@ -1,0 +1,11 @@
+# Aggregate project
+
+Aggregate Maven project, containing a root pom and two modules. One of the modules (web) depends on
+another modules (core) using an inherited property.
+
+Only the Maven Reactor is capable of resolving this inter module dependency.
+
+By passing option `mavenAggregateProject` the maven command run parses all digraphs and returns a multi plugin result
+containing an array of scan results.
+
+Tested by [../system/reactor.test.ts](reactor.test.ts)

--- a/tests/fixtures/complex-aggregate-project/core/pom.xml
+++ b/tests/fixtures/complex-aggregate-project/core/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.snyk</groupId>
+    <artifactId>aggregate-project</artifactId>
+    <version>1.0.0</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>core</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/fixtures/complex-aggregate-project/pom.xml
+++ b/tests/fixtures/complex-aggregate-project/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk</groupId>
+  <artifactId>aggregate-project</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <spring.version>5.3.21</spring.version>
+    <log4j.version>2.17.2</log4j.version>
+  </properties>
+
+  <modules>
+    <module>core</module>
+    <module>web</module>
+  </modules>
+
+</project>

--- a/tests/fixtures/complex-aggregate-project/web/pom.xml
+++ b/tests/fixtures/complex-aggregate-project/web/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.snyk</groupId>
+    <artifactId>aggregate-project</artifactId>
+    <version>1.0.0</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>web</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.snyk</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/functional/dep-graph.test.ts
+++ b/tests/functional/dep-graph.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap';
-import { buildDepGraph } from '../../../lib/parse/dep-graph';
+import { buildDepGraph } from '../../lib/parse/dep-graph';
 
 test('buildDepGraph', async (t) => {
   const depGraph = buildDepGraph({

--- a/tests/functional/dependency.test.ts
+++ b/tests/functional/dependency.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap';
-import { parseDependency } from '../../../lib/parse/dependency';
+import { parseDependency } from '../../lib/parse/dependency';
 
 test('parseDependency returns expected object', async (t) => {
   t.same(

--- a/tests/functional/digraph.test.ts
+++ b/tests/functional/digraph.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap';
-import { parseDigraphs } from '../../../lib/parse/digraph';
+import { parseDigraphs } from '../../lib/parse/digraph';
 
 const core = `digraph "io.snyk:core:jar:1.0.0" { 
 "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ; 

--- a/tests/functional/maven-graph-builder.test.ts
+++ b/tests/functional/maven-graph-builder.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap';
-import { MavenGraphBuilder } from '../../../lib/parse/maven-graph-builder';
+import { MavenGraphBuilder } from '../../lib/parse/maven-graph-builder';
 
 test('default constructor', async (t) => {
   const builder = new MavenGraphBuilder('root');

--- a/tests/functional/mvn-plugin.test.ts
+++ b/tests/functional/mvn-plugin.test.ts
@@ -16,3 +16,26 @@ test('buildArgs with array', async (t) => {
     'should return expected array',
   );
 });
+
+test('buildArgs with option mavenAggregateProject', async (t) => {
+  const mavenAggregateProject = true;
+  const result = plugin.buildArgs(
+    '.',
+    '.',
+    'pom.xml',
+    ['-Paxis', '-Pjaxen'],
+    mavenAggregateProject,
+  );
+  t.same(
+    result,
+    [
+      'test-compile',
+      'dependency:tree',
+      '-DoutputType=dot',
+      '--batch-mode',
+      '-Paxis',
+      '-Pjaxen',
+    ],
+    'should return expected array',
+  );
+});

--- a/tests/functional/parse-mvn.test.ts
+++ b/tests/functional/parse-mvn.test.ts
@@ -1,5 +1,5 @@
 import * as test from 'tap-only';
-import { readFixture, readFixtureJSON } from '../file-helper';
+import { readFixture, readFixtureJSON } from '../helpers/read';
 import { parseTree, parseVersions } from '../../lib/parse-mvn';
 
 test('parseTree without --dev', async (t) => {
@@ -8,7 +8,7 @@ test('parseTree without --dev', async (t) => {
   );
   const depTree = parseTree(mavenOutput, false);
   const results = await readFixtureJSON('parse-mvn/maven-parse-results.json');
-  t.same(depTree.data, results, 'should return expected results');
+  t.same(depTree.package, results, 'should return expected results');
 });
 
 test('parseTree with --dev', async (t) => {
@@ -19,7 +19,7 @@ test('parseTree with --dev', async (t) => {
   const results = await readFixtureJSON(
     'parse-mvn/maven-parse-dev-results.json',
   );
-  t.same(depTree.data, results, 'should return expected results');
+  t.same(depTree.package, results, 'should return expected results');
 });
 
 test('parseTree given duplicate dep with classifier', async (t) => {
@@ -30,7 +30,7 @@ test('parseTree given duplicate dep with classifier', async (t) => {
   const results = await readFixtureJSON(
     'parse-mvn/duplicate-dep-with-classifier-results.json',
   );
-  t.same(depTree.data, results, 'should return expected results');
+  t.same(depTree.package, results, 'should return expected results');
 });
 
 test('parseTree with bad mvn dependency:tree output', async (t) => {
@@ -78,9 +78,9 @@ test('parseTree with type "test-jar" in mvn dependency', async (t) => {
     'parse-mvn/maven-dependency-tree-with-type.txt',
   );
   const result = parseTree(mavenOutput, true);
-  if (result && result.data && result.data.dependencies) {
+  if (result && result.package && result.package.dependencies) {
     t.equals(
-      result.data.dependencies['com.snyk.tester:tester-queue'].version,
+      result.package.dependencies['com.snyk.tester:tester-queue'].version,
       '15.0.0',
     );
   } else {

--- a/tests/functional/stdout.test.ts
+++ b/tests/functional/stdout.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap';
-import { parseStdout } from '../../../lib/parse/stdout';
+import { parseStdout } from '../../lib/parse/stdout';
 
 const singleProjectStdout = `[INFO] Scanning for projects...
 [INFO] 

--- a/tests/helpers/read.ts
+++ b/tests/helpers/read.ts
@@ -1,12 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+const fixtures = path.join(__dirname, '..', 'fixtures');
+
 /**
  * Asynchronous fs.readFile.
  */
 export async function readFile(path): Promise<string> {
   return new Promise((resolve, reject) => {
-    fs.readFile(path, 'utf8', function(err, data) {
+    fs.readFile(path, 'utf8', function (err, data) {
       if (err) {
         reject(err);
       }
@@ -35,7 +37,7 @@ export async function readJSON(filePath: string) {
  * @param fixturePath path relative to test fixtures directory.
  */
 export async function readFixture(...paths: string[]) {
-  const filePath = path.join(__dirname, 'fixtures', ...paths);
+  const filePath = path.join(fixtures, ...paths);
   return await readFile(filePath);
 }
 
@@ -45,6 +47,6 @@ export async function readFixture(...paths: string[]) {
  * @param fixturePath path relative to test fixtures directory.
  */
 export async function readFixtureJSON(...paths: string[]) {
-  const filePath = path.join(__dirname, 'fixtures', ...paths);
+  const filePath = path.join(fixtures, ...paths);
   return await readJSON(filePath);
 }

--- a/tests/helpers/sort.ts
+++ b/tests/helpers/sort.ts
@@ -1,0 +1,5 @@
+import type { PkgInfo } from '@snyk/dep-graph';
+
+export function byPkgName(a: PkgInfo, b: PkgInfo): number {
+  return a.name.length - b.name.length;
+}

--- a/tests/system/plugin-jar.test.ts
+++ b/tests/system/plugin-jar.test.ts
@@ -3,7 +3,7 @@ import * as depGraphLib from '@snyk/dep-graph';
 import * as path from 'path';
 import * as test from 'tap-only';
 import * as plugin from '../../lib';
-import { readFixtureJSON } from '../file-helper';
+import { readFixtureJSON } from '../helpers/read';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');

--- a/tests/system/plugin-reachable-vulns.test.ts
+++ b/tests/system/plugin-reachable-vulns.test.ts
@@ -5,7 +5,7 @@ import * as javaCallGraphBuilder from '@snyk/java-call-graph-builder';
 import { CallGraph } from '@snyk/cli-interface/legacy/common';
 
 import * as plugin from '../../lib';
-import { readFixtureJSON } from '../file-helper';
+import { readFixtureJSON } from '../helpers/read';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -3,7 +3,7 @@ import * as test from 'tap-only';
 import { legacyPlugin } from '@snyk/cli-interface';
 
 import * as plugin from '../../lib';
-import { readFixtureJSON } from '../file-helper';
+import { readFixtureJSON } from '../helpers/read';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');

--- a/tests/system/reactor.test.ts
+++ b/tests/system/reactor.test.ts
@@ -1,0 +1,80 @@
+import type { PkgInfo } from '@snyk/dep-graph';
+import * as path from 'path';
+import { test } from 'tap';
+import { legacyPlugin } from '@snyk/cli-interface';
+import * as plugin from '../../lib';
+import { byPkgName } from '../helpers/sort';
+
+const testsPath = path.join(__dirname, '..');
+const fixturesPath = path.join(testsPath, 'fixtures');
+
+function getDepPkgs(
+  rootPkgName: string,
+  result: legacyPlugin.MultiProjectResult,
+): PkgInfo[] | undefined {
+  const project = result.scannedProjects.find(
+    (p) => p.depGraph?.rootPkg.name === rootPkgName,
+  );
+  return project?.depGraph?.getDepPkgs();
+}
+
+test('inspect on complex aggregate project using maven reactor', async (t) => {
+  const result = await plugin.inspect(
+    path.join(fixturesPath, 'complex-aggregate-project'),
+    'pom.xml',
+    {
+      mavenAggregateProject: true,
+    },
+  );
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+  t.equal(result.scannedProjects.length, 3, 'should return 3 scanned projects');
+  t.equal(
+    getDepPkgs('io.snyk:aggregate-project', result)?.length,
+    0,
+    'root project has 0 dependencies',
+  );
+  t.same(
+    getDepPkgs('io.snyk:core', result)?.sort(byPkgName),
+    [
+      { name: 'org.apache.logging.log4j:log4j-api', version: '2.17.2' },
+      { name: 'org.apache.logging.log4j:log4j-core', version: '2.17.2' },
+    ].sort(byPkgName),
+    'core project has 2 dependencies',
+  );
+  t.same(
+    getDepPkgs('io.snyk:web', result)?.sort(byPkgName),
+    [
+      // depends on another module
+      { name: 'io.snyk:core', version: '1.0.0' },
+      // and that modules transitives
+      {
+        name: 'org.apache.logging.log4j:log4j-api',
+        version: '2.17.2',
+      },
+      // as well as it's own dependencies
+      {
+        name: 'org.apache.logging.log4j:log4j-core',
+        version: '2.17.2',
+      },
+      {
+        name: 'org.springframework:spring-web',
+        version: '5.3.21',
+      },
+      {
+        name: 'org.springframework:spring-beans',
+        version: '5.3.21',
+      },
+      {
+        name: 'org.springframework:spring-core',
+        version: '5.3.21',
+      },
+      {
+        name: 'org.springframework:spring-jcl',
+        version: '5.3.21',
+      },
+    ].sort(byPkgName),
+    'web project has own dependencies and another modules',
+  );
+});


### PR DESCRIPTION
Introduce a new option to test a project using one maven command but return multiple scan results.

If option 'mavenAggregateProject' is true, perform 'mvn test-compile dependency:tree -DoutputType=dot'.
This command better supports more complex Maven projects where modules depend on one another and are not discoverable in either a local or remote repositories.
In this mode we rely on the Maven reactor resolving inter module dependencies and reporting multiple digraphs on stdout which we parse into a MavenGraph and then into a Snyk dep-graph.

Fixes:
* https://github.com/snyk/snyk-mvn-plugin/issues/124
* https://github.com/snyk/snyk-mvn-plugin/issues/38