### PR TITLE
chore: update supported node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 ![Snyk logo](https://snyk.io/style/asset/logo/snyk-print.svg)
 
-
 [![Known Vulnerabilities](https://snyk.io/test/github/snyk/snyk-mvn-plugin/badge.svg?targetFile=package.json)](https://snyk.io/test/github/snyk/snyk-mvn-plugin?targetFile=package.json)
 
-
-
-***
+---
 
 Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
 
 | :information_source: This repository is only a plugin to be used with the Snyk CLI tool. To use this plugin to test and fix vulnerabilities in your project, install the Snyk CLI tool first. Head over to [snyk.io](https://github.com/snyk/snyk) to get started. |
-| --- |
-
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 
 ## Snyk Maven CLI Plugin
 
@@ -27,28 +23,20 @@ If you are looking to add tasks to your Maven build process you should use our [
 
 ## Supported OS
 
-| OS     |  Supported |
-|--------|------------|
-| Windows| ✅          |
-| Linux  | ✅          |
-| OSX    | ️✅          |
+| OS      | Supported |
+| ------- | --------- |
+| Windows | ✅        |
+| Linux   | ✅        |
+| OSX     | ️✅       |
 
 ## Supported Node versions
 
-| Node  |  Supported |
-|-------|------------|
-| 6     | ✅          |
-| 8     | ✅          |
-| 10    | ✅          |
-| 12    | ✅          |
+| Node | Supported |
+| ---- | --------- |
+| 12   | ✅        |
+| 14   | ✅        |
+| 16   | ✅        |
 
-## Supported Java & Maven versions
+## Supported Maven versions
 
-| Java / Maven|3.* |
-|----------------|---|
-| 8 (LTS)        | ✅ |
-| 9              | ✅ |
-| 10             | ✅ |
-| 11 (LTS)       | ✅ |
-| 12             | ✅ | 
-| 13             | ✅ |
+This plugin supports Maven versions 3.\*


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Snyk CLI supports Node versions >= 12, updating the README for this plugin accordingly
If Maven requires a specific Java version, this requirement is not directly related to what the plugin requires. The Java/Maven is redundant - remove it.
