### PR TITLE
feat: use /rest/packages when searching by checksum

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,7 @@ import {
 import { formatGenericPluginError } from './error-format';
 import debugModule = require('debug');
 import { parse } from './parse';
+import { SnykHttpClient } from './parse/types';
 
 const WRAPPERS = ['mvnw', 'mvnw.cmd'];
 // To enable debugging output, use `snyk -d`
@@ -104,6 +105,7 @@ export async function inspect(
   root: string,
   targetFile?: string,
   options?: MavenOptions,
+  snykHttpClient?: SnykHttpClient,
 ): Promise<legacyPlugin.InspectResult> {
   const targetPath = targetFile
     ? path.resolve(root, targetFile)
@@ -117,7 +119,11 @@ export async function inspect(
 
   if (targetPath && isArchive(targetPath)) {
     debug(`Creating dep-graph from ${targetPath}`);
-    const depGraph = await createDepGraphFromArchive(root, targetPath);
+    const depGraph = await createDepGraphFromArchive(
+      root,
+      targetPath,
+      snykHttpClient,
+    );
     return {
       plugin: {
         name: 'bundled:maven',
@@ -134,7 +140,11 @@ export async function inspect(
     const archives = findArchives(root, recursive);
     if (archives.length > 0) {
       debug(`Creating dep-graph from archives in ${root}`);
-      const depGraph = await createDepGraphFromArchives(root, archives);
+      const depGraph = await createDepGraphFromArchives(
+        root,
+        archives,
+        snykHttpClient,
+      );
       return {
         plugin: {
           name: 'bundled:maven',

--- a/lib/parse/types.ts
+++ b/lib/parse/types.ts
@@ -1,7 +1,40 @@
-export interface MavenDependency {
+import type { OutgoingHttpHeaders } from 'http';
+
+export type HttpClientVerbs =
+  | 'get'
+  | 'head'
+  | 'delete'
+  | 'patch'
+  | 'post'
+  | 'put';
+
+export interface RequestInfo {
+  method: HttpClientVerbs;
+  path: string;
+  body?: unknown;
+  headers?: OutgoingHttpHeaders;
+  qs?: Record<string, string>;
+  json?: boolean;
+  timeout?: number;
+  family?: number;
+}
+
+export interface HttpClientResponse {
+  statusCode?: number;
+}
+
+export type SnykHttpClient = (requestInfo: RequestInfo) => Promise<{
+  res: HttpClientResponse;
+  body: unknown;
+}>;
+
+export interface MavenPackage {
   groupId: string;
   artifactId: string;
   version: string;
+}
+
+export interface MavenDependency extends MavenPackage {
   type: string;
   classifier?: string;
   scope?: string;
@@ -10,6 +43,15 @@ export interface MavenDependency {
 export interface MavenGraph {
   rootId: string;
   nodes: Record<string, MavenGraphNode>;
+}
+
+export interface PackageResource {
+  id: string;
+  type: 'package';
+}
+
+export interface GetPackageData {
+  data: Array<PackageResource>;
 }
 
 export interface MavenGraphNode {

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,101 @@
+import {
+  GetPackageData,
+  PackageResource,
+  MavenPackage,
+  SnykHttpClient,
+} from './parse/types';
+import { PackageURL } from 'packageurl-js';
+import * as debugLib from 'debug';
+import * as path from 'path';
+
+const debug = debugLib('snyk-mvn-plugin');
+
+const PACKAGE_SEARCH_TYPE = 'maven';
+const PACKAGE_SEARCH_ENDPOINT = '/packages';
+const PACKAGE_SEARCH_VERSION = '2022-09-21~beta';
+
+export async function getMavenPackageInfo(
+  sha1: string,
+  targetPath: string,
+  snykHttpClient: SnykHttpClient,
+): Promise<MavenPackage> {
+  const searchResults = await searchMavenPackageByChecksum(
+    sha1,
+    targetPath,
+    snykHttpClient,
+  );
+  if (searchResults.length == 0) {
+    return fallbackPackageInfo(sha1, targetPath);
+  }
+
+  let foundPackage: MavenPackage | undefined;
+  if (searchResults.length > 1) {
+    const sha1Target = path.parse(targetPath).base;
+    debug(`Got multiple results for ${sha1}, looking for ${sha1Target}`);
+    foundPackage = searchResults.find((result) =>
+      sha1Target.includes(result.groupId),
+    );
+  }
+
+  return foundPackage || searchResults[0];
+}
+
+async function searchMavenPackageByChecksum(
+  sha1: string,
+  targetPath: string,
+  snykHttpClient: SnykHttpClient,
+): Promise<Array<MavenPackage>> {
+  const { res, body } = await snykHttpClient({
+    method: 'get',
+    path: PACKAGE_SEARCH_ENDPOINT,
+    qs: {
+      version: PACKAGE_SEARCH_VERSION,
+      package_type: PACKAGE_SEARCH_TYPE,
+      package_sha1: sha1,
+    },
+  });
+
+  if (!res?.statusCode || res?.statusCode >= 400 || !body) {
+    debug(`Failed to resolve ${targetPath} using sha1 ${sha1}.`);
+    return [];
+  }
+
+  return mapPackageSearchResult(body as GetPackageData, sha1, targetPath);
+}
+
+function mapPackageSearchResult(
+  body: GetPackageData,
+  sha1: string,
+  targetPath: string,
+): Array<MavenPackage> {
+  return body.data
+    .map((purl: PackageResource) => {
+      try {
+        const pkg = PackageURL.fromString(purl.id);
+        const fallback = fallbackPackageInfo(sha1, targetPath);
+
+        return {
+          groupId: pkg.namespace || fallback.groupId,
+          artifactId: pkg.name || fallback.artifactId,
+          version: pkg.version || fallback.version,
+        };
+      } catch (_error) {
+        debug(
+          `Failed to parse package url components for ${targetPath} using sha1 '${sha1}.`,
+        );
+        return undefined;
+      }
+    })
+    .filter(
+      (mvnPackage: MavenPackage | undefined): mvnPackage is MavenPackage =>
+        mvnPackage !== undefined,
+    );
+}
+
+function fallbackPackageInfo(sha1: string, targetPath: string): MavenPackage {
+  return {
+    groupId: 'unknown',
+    artifactId: `${targetPath}:${sha1}`,
+    version: 'unknown',
+  };
+}

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   "dependencies": {
     "@snyk/cli-interface": "2.11.3",
     "@snyk/dep-graph": "^1.23.1",
+    "packageurl-js": "^1.0.0",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
-    "needle": "^2.5.0",
     "shescape": "1.6.1",
     "tslib": "^2.4.0"
   }

--- a/tests/helpers/mock-search.ts
+++ b/tests/helpers/mock-search.ts
@@ -1,0 +1,91 @@
+import {
+  GetPackageData,
+  HttpClientResponse,
+  RequestInfo,
+} from '../../lib/parse/types';
+
+const FIXTURES: Map<
+  String,
+  {
+    res: HttpClientResponse;
+    body: GetPackageData;
+  }
+> = new Map(
+  Object.entries({
+    da7a3f411b9e7bba70f7a7f9ffa00756c9be2ec1: {
+      res: { statusCode: 200 },
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/com.packetzoom/pz-okhttp-interceptor-fat@3.2.43',
+            type: 'package',
+          },
+        ],
+      },
+    },
+    c334e3e4b6da8a5e2123c28cd9e397fae15eb025: {
+      res: { statusCode: 200 },
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/tomcat/tomcat-http11@4.1.34',
+            type: 'package',
+          },
+        ],
+      },
+    },
+    '396d478d08515ddc36a5c9c8b8d95f1a5a7c3e17': {
+      res: { statusCode: 200 },
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/org.keycloak/keycloak-core@5.0.0',
+            type: 'package',
+          },
+        ],
+      },
+    },
+    '815893df5f31da2ece4040fe0a12fd44b577afaf': {
+      res: { statusCode: 200 },
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/org.netbeans.external/org-apache-commons-io@RELEASE113',
+            type: 'package',
+          },
+          {
+            id: 'pkg:maven/commons-io/commons-io@2.6',
+            type: 'package',
+          },
+        ],
+      },
+    },
+    '37fd45c92cfd05b9ad173ee1184ec4221e0f931f': {
+      res: { statusCode: 200 },
+      body: {
+        data: [
+          {
+            id: 'pkg:maven/org.springframework/spring-core@5.1.8.RELEASE',
+            type: 'package',
+          },
+        ],
+      },
+    },
+  }),
+);
+
+export async function mockSnykSearchClient(requestInfo: RequestInfo): Promise<{
+  res: HttpClientResponse;
+  body: any;
+}> {
+  if (requestInfo.method == 'get' || requestInfo.path == '/packages') {
+    const sha1 = requestInfo.qs?.package_sha1 || '';
+    const packageInfo = FIXTURES.get(sha1);
+
+    if (packageInfo) {
+      return packageInfo;
+    }
+  }
+
+  return { res: { statusCode: 404 }, body: undefined };
+}

--- a/tests/system/plugin-jar.test.ts
+++ b/tests/system/plugin-jar.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as test from 'tap-only';
 import * as plugin from '../../lib';
 import { readFixtureJSON } from '../helpers/read';
+import { mockSnykSearchClient } from '../helpers/mock-search';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');
@@ -24,7 +25,12 @@ test('inspect with aar file', async (t) =>
   }));
 
 test('inspect on altered jar marks package as unknown', async (t) => {
-  const result = await plugin.inspect(badPath, 'jackson-databind-2.9.9.jar');
+  const result = await plugin.inspect(
+    badPath,
+    'jackson-databind-2.9.9.jar',
+    undefined,
+    mockSnykSearchClient,
+  );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
   }
@@ -40,7 +46,12 @@ test('inspect on altered jar marks package as unknown', async (t) => {
 
 test('inspect on non-existent jar', async (t) => {
   try {
-    await plugin.inspect(__dirname, 'nowhere-to-be-found-1.0.jar');
+    await plugin.inspect(
+      __dirname,
+      'nowhere-to-be-found-1.0.jar',
+      undefined,
+      mockSnykSearchClient,
+    );
     t.fail('expected inspect to throw error');
   } catch (err) {
     if (err instanceof Error) {
@@ -57,7 +68,12 @@ test('inspect on non-existent jar', async (t) => {
 });
 
 test('inspect on user created jar marks package as unknown', async (t) => {
-  const result = await plugin.inspect(badPath, 'mvn-app-1.0-SNAPSHOT.jar');
+  const result = await plugin.inspect(
+    badPath,
+    'mvn-app-1.0-SNAPSHOT.jar',
+    undefined,
+    mockSnykSearchClient,
+  );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
   }
@@ -88,7 +104,12 @@ test('inspect on target pom file in directory with jars and --scan-all-unmanaged
 
 test('inspect in directory with no jars no target file and --scan-all-unmanaged arg', async (t) => {
   try {
-    await plugin.inspect(__dirname, undefined, { scanAllUnmanaged: true });
+    await plugin.inspect(
+      __dirname,
+      undefined,
+      { scanAllUnmanaged: true },
+      mockSnykSearchClient,
+    );
     t.fail('expected inspect to throw error');
   } catch (err) {
     if (err instanceof Error) {
@@ -105,9 +126,14 @@ test('inspect in directory with no jars no target file and --scan-all-unmanaged 
 
 test('inspect in directory with good and bad jars and --scan-all-unmanaged arg', async (t) => {
   const root = path.join(fixturesPath, 'good-and-bad');
-  const result = await plugin.inspect(root, undefined, {
-    scanAllUnmanaged: true,
-  });
+  const result = await plugin.inspect(
+    root,
+    undefined,
+    {
+      scanAllUnmanaged: true,
+    },
+    mockSnykSearchClient,
+  );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
   }
@@ -156,7 +182,12 @@ async function assertFixture({
   options?: any;
 }) {
   const root = path.join(fixturesPath, fixtureDirectory);
-  const result = await plugin.inspect(root, targetFile, options);
+  const result = await plugin.inspect(
+    root,
+    targetFile,
+    options,
+    mockSnykSearchClient,
+  );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
   }

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -4,6 +4,7 @@ import { legacyPlugin } from '@snyk/cli-interface';
 
 import * as plugin from '../../lib';
 import { readFixtureJSON } from '../helpers/read';
+import { mockSnykSearchClient } from '../helpers/mock-search';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');
@@ -13,6 +14,8 @@ test('inspect on test-project pom', async (t) => {
   const result = await plugin.inspect(
     '.',
     path.join(testProjectPath, 'pom.xml'),
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -39,6 +42,7 @@ test('inspect on test-project pom with --dev', async (t) => {
     {
       dev: true,
     },
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -65,6 +69,8 @@ test('inspect on path with spaces pom', async (t) => {
   const result = await plugin.inspect(
     '.',
     path.join(fixturesPath, 'path with spaces', 'pom.xml'),
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -88,6 +94,8 @@ test('inspect on relative path to test-project pom', async (t) => {
   const result = await plugin.inspect(
     __dirname,
     path.join('..', 'fixtures', 'test-project', 'pom.xml'),
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -111,6 +119,8 @@ test('inspect on relative path to test-project dir', async (t) => {
   const result = await plugin.inspect(
     __dirname,
     path.join('..', 'fixtures', 'test-project'),
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -131,7 +141,12 @@ test('inspect on relative path to test-project dir', async (t) => {
 });
 
 test('inspect on root that contains pom.xml and no target file', async (t) => {
-  const result = await plugin.inspect(testProjectPath);
+  const result = await plugin.inspect(
+    testProjectPath,
+    undefined,
+    undefined,
+    mockSnykSearchClient,
+  );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
   }
@@ -152,7 +167,7 @@ test('inspect on root that contains pom.xml and no target file', async (t) => {
 
 test('inspect on root that does not contain a pom.xml and no target file', async (t) => {
   try {
-    await plugin.inspect(__dirname);
+    await plugin.inspect(__dirname, undefined, undefined, mockSnykSearchClient);
     t.fail('expected inspect to throw error');
   } catch (err) {
     if (err instanceof Error) {
@@ -178,6 +193,7 @@ test('inspect on pom with plugin', async (t) => {
       '.',
       path.join(fixturesPath, 'bad', 'pom.plugin.xml'),
       { dev: true },
+      mockSnykSearchClient,
     );
     t.fail('expected inspect to throw error');
   } catch (err) {
@@ -195,9 +211,14 @@ test('inspect on pom with plugin', async (t) => {
 
 test('inspect on pom with bad dependency', async (t) => {
   try {
-    await plugin.inspect('.', path.join(fixturesPath, 'bad', 'pom.xml'), {
-      dev: true,
-    });
+    await plugin.inspect(
+      '.',
+      path.join(fixturesPath, 'bad', 'pom.xml'),
+      {
+        dev: true,
+      },
+      mockSnykSearchClient,
+    );
     t.fail('expected inspect to throw error');
   } catch (err) {
     if (err instanceof Error) {
@@ -221,9 +242,14 @@ test('inspect on mvn error', async (t) => {
   const targetFile = path.join(fixturesPath, 'bad', 'pom.xml');
   const fullCommand = `mvn dependency:tree -DoutputType=dot --batch-mode --non-recursive --file="${targetFile}"`;
   try {
-    await plugin.inspect('.', targetFile, {
-      dev: true,
-    });
+    await plugin.inspect(
+      '.',
+      targetFile,
+      {
+        dev: true,
+      },
+      mockSnykSearchClient,
+    );
     t.fail('expected inspect to throw error');
   } catch (err) {
     if (err instanceof Error) {
@@ -252,9 +278,14 @@ test('inspect on mvn error', async (t) => {
 test('inspect on mvnw error', async (t) => {
   const targetFile = path.join(fixturesPath, 'bad-maven-with-mvnw', 'pom.xml');
   try {
-    await plugin.inspect('.', targetFile, {
-      dev: true,
-    });
+    await plugin.inspect(
+      '.',
+      targetFile,
+      {
+        dev: true,
+      },
+      mockSnykSearchClient,
+    );
     t.fail('expected inspect to throw error');
   } catch (err) {
     if (err instanceof Error) {
@@ -274,6 +305,9 @@ test('inspect on mvnw error', async (t) => {
 test('inspect on mvnw is successful', async (t) => {
   const result = await plugin.inspect(
     path.join(fixturesPath, 'maven-with-mvnw'),
+    undefined,
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -297,6 +331,8 @@ test('inspect on mvnw is successful with targetFile', async (t) => {
   const result = await plugin.inspect(
     '.',
     path.join(fixturesPath, 'maven-with-mvnw', 'pom.xml'),
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -320,6 +356,8 @@ test('inspect on mvnw successful when resides in parent directory with targetFil
   const result = await plugin.inspect(
     path.join(fixturesPath, 'wrapper-at-parent'),
     path.join(fixturesPath, 'wrapper-at-parent', 'project-a', 'pom.xml'),
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');
@@ -343,6 +381,8 @@ test('inspect on aggregate project root pom', async (t) => {
   const result = await plugin.inspect(
     path.join(fixturesPath, 'aggregate-project'),
     'pom.xml',
+    undefined,
+    mockSnykSearchClient,
   );
   if (legacyPlugin.isMultiResult(result)) {
     return t.fail('expected single inspect result');

--- a/tests/system/reactor.test.ts
+++ b/tests/system/reactor.test.ts
@@ -4,6 +4,7 @@ import { test } from 'tap';
 import { legacyPlugin } from '@snyk/cli-interface';
 import * as plugin from '../../lib';
 import { byPkgName } from '../helpers/sort';
+import { mockSnykSearchClient } from '../helpers/mock-search';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');
@@ -25,12 +26,17 @@ test('inspect on complex aggregate project using maven reactor', async (t) => {
     {
       mavenAggregateProject: true,
     },
+    mockSnykSearchClient,
   );
   if (!legacyPlugin.isMultiResult(result)) {
     return t.fail('expected multi inspect result');
   }
-  t.equal(result.scannedProjects.length, 3, 'should return 3 scanned projects');
-  t.equal(
+  t.strictEqual(
+    result.scannedProjects.length,
+    3,
+    'should return 3 scanned projects',
+  );
+  t.strictEqual(
     getDepPkgs('io.snyk:aggregate-project', result)?.length,
     0,
     'root project has 0 dependencies',
@@ -53,7 +59,7 @@ test('inspect on complex aggregate project using maven reactor', async (t) => {
         name: 'org.apache.logging.log4j:log4j-api',
         version: '2.17.2',
       },
-      // as well as it's own dependencies
+      // as well as its own dependencies
       {
         name: 'org.apache.logging.log4j:log4j-core',
         version: '2.17.2',


### PR DESCRIPTION
#### What does this PR do?

Change the unmanaged package search to use /rest/packages
instead of maven central. 

#### What are the relevant tickets?

[Jira ticket TARDIS-1031](https://snyksec.atlassian.net/browse/TARDIS-1031)

