### PR TITLE
fix: support --dev and --maven-aggregate-project

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -184,7 +184,7 @@ export async function inspect(
     );
     let parseResult = {};
     if (options.mavenAggregateProject) {
-      parseResult = parse(result);
+      parseResult = parse(result, options.dev);
     } else {
       parseResult = parseTree(result, options.dev);
     }

--- a/lib/parse/index.ts
+++ b/lib/parse/index.ts
@@ -4,12 +4,15 @@ import { parseStdout } from './stdout';
 import { parseDigraphs } from './digraph';
 import { buildDepGraph } from './dep-graph';
 
-export function parse(stdout: string): { scannedProjects: ScannedProject[] } {
+export function parse(
+  stdout: string,
+  includeTestScope = false,
+): { scannedProjects: ScannedProject[] } {
   const digraphs = parseStdout(stdout);
   const mavenGraphs = parseDigraphs(digraphs);
   const scannedProjects: ScannedProject[] = [];
   for (const mavenGraph of mavenGraphs) {
-    const depGraph = buildDepGraph(mavenGraph);
+    const depGraph = buildDepGraph(mavenGraph, includeTestScope);
     scannedProjects.push({ depGraph });
   }
   return {

--- a/tests/fixtures/complex-aggregate-project/pom.xml
+++ b/tests/fixtures/complex-aggregate-project/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <spring.version>5.3.21</spring.version>
     <log4j.version>2.17.2</log4j.version>
+    <junit.version>5.8.1</junit.version>
   </properties>
 
   <modules>

--- a/tests/fixtures/complex-aggregate-project/web/pom.xml
+++ b/tests/fixtures/complex-aggregate-project/web/pom.xml
@@ -23,5 +23,11 @@
       <artifactId>spring-web</artifactId>
       <version>${spring.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tests/system/reactor.test.ts
+++ b/tests/system/reactor.test.ts
@@ -4,7 +4,6 @@ import { test } from 'tap';
 import { legacyPlugin } from '@snyk/cli-interface';
 import * as plugin from '../../lib';
 import { byPkgName } from '../helpers/sort';
-import { mockSnykSearchClient } from '../helpers/mock-search';
 
 const testsPath = path.join(__dirname, '..');
 const fixturesPath = path.join(testsPath, 'fixtures');
@@ -26,7 +25,6 @@ test('inspect on complex aggregate project using maven reactor', async (t) => {
     {
       mavenAggregateProject: true,
     },
-    mockSnykSearchClient,
   );
   if (!legacyPlugin.isMultiResult(result)) {
     return t.fail('expected multi inspect result');
@@ -82,5 +80,78 @@ test('inspect on complex aggregate project using maven reactor', async (t) => {
       },
     ].sort(byPkgName),
     'web project has own dependencies and another modules',
+  );
+});
+
+test('inspect on complex aggregate project using maven reactor include test scope', async (t) => {
+  const result = await plugin.inspect(
+    path.join(fixturesPath, 'complex-aggregate-project'),
+    'pom.xml',
+    {
+      mavenAggregateProject: true,
+      dev: true,
+    },
+  );
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+  t.same(
+    getDepPkgs('io.snyk:web', result)?.sort(byPkgName),
+    [
+      // depends on another module
+      { name: 'io.snyk:core', version: '1.0.0' },
+      // and that modules transitives
+      {
+        name: 'org.apache.logging.log4j:log4j-api',
+        version: '2.17.2',
+      },
+      // as well as its own dependencies
+      {
+        name: 'org.apache.logging.log4j:log4j-core',
+        version: '2.17.2',
+      },
+      {
+        name: 'org.springframework:spring-web',
+        version: '5.3.21',
+      },
+      {
+        name: 'org.springframework:spring-beans',
+        version: '5.3.21',
+      },
+      {
+        name: 'org.springframework:spring-core',
+        version: '5.3.21',
+      },
+      {
+        name: 'org.springframework:spring-jcl',
+        version: '5.3.21',
+      },
+      // includes test dependencies (when --dev used)
+      {
+        name: 'org.junit.jupiter:junit-jupiter-api',
+        version: '5.8.1',
+      },
+      {
+        name: 'org.junit.jupiter:junit-jupiter-engine',
+        version: '5.8.1',
+      },
+      {
+        name: 'org.junit.platform:junit-platform-engine',
+        version: '1.8.1',
+      },
+      {
+        name: 'org.junit.platform:junit-platform-commons',
+        version: '1.8.1',
+      },
+      {
+        name: 'org.apiguardian:apiguardian-api',
+        version: '1.1.2',
+      },
+      {
+        name: 'org.opentest4j:opentest4j',
+        version: '1.2.0',
+      },
+    ].sort(byPkgName),
+    'web project has own dependencies, another modules and test dependencies',
   );
 });


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
At the moment we include all dependencies regardless of the --dev flag when using --maven-aggregate-project.

Changing this so that only when users pass --dev we include test scope. When no --dev flag provided we default to ignoring test scopes. This is the case in most other Snyk CLI plugins.
