### PR TITLE
fix: semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,14 +165,12 @@ jobs:
   release:
     <<: *defaults
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:lts
     steps:
       - checkout
-      - install_deps
-      - run: sudo npm i -g semantic-release @semantic-release/exec pkg
       - run:
           name: Publish to GitHub
-          command: semantic-release
+          command: npx semantic-release
 
 workflows:
   version: 2


### PR DESCRIPTION
Use the latest versions of node and semantic release when publishing to GitHub.
