### PR TITLE
fix: install deps before release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ jobs:
       - image: cimg/node:lts
     steps:
       - checkout
+      - install_deps
       - run:
           name: Publish to GitHub
           command: npx semantic-release


### PR DESCRIPTION
Seeing errors when releasing, which suggest we need to install deps before running semantic-release