### PR TITLE
fix: output with warnings and env vars

### DIFF
--- a/lib/parse-digraph.ts
+++ b/lib/parse-digraph.ts
@@ -1,0 +1,6 @@
+const regex = /digraph([\s\S]*?)\}[\s]*?$/gm;
+
+export function parseDigraph(text: string): string[] | null {
+  const result = text.match(regex);
+  return result || null;
+}

--- a/lib/parse-mvn.ts
+++ b/lib/parse-mvn.ts
@@ -1,9 +1,9 @@
 import { legacyCommon } from '@snyk/cli-interface';
+import { parseDigraph } from './parse-digraph';
 import { parseDependency } from './parse/dependency';
 
 const newline = /[\r\n]+/g;
 const logLabel = /^\[\w+\]\s*/gm;
-const digraph = /digraph([\s\S]*?)\}/g;
 const errorLabel = /^\[ERROR\]/gm;
 
 // Parse the output from 'mvn dependency:tree -DoutputType=dot'
@@ -36,7 +36,7 @@ export function parseVersions(text: string): {
 }
 
 function getRootProject(text, withDev) {
-  const projects = text.match(digraph);
+  const projects = parseDigraph(text);
   if (!projects) {
     throw new Error('Cannot find dependency information.');
   }

--- a/lib/parse/stdout.ts
+++ b/lib/parse/stdout.ts
@@ -1,5 +1,6 @@
+import { parseDigraph } from '../parse-digraph';
+
 const logLabel = /^\[\w+\]\s*/gm;
-const digraph = /digraph([\s\S]*?)\}/g;
 const errorLabel = /^\[ERROR\]/gm;
 
 // Parse the output from 'mvn dependency:tree -DoutputType=dot'
@@ -7,7 +8,8 @@ export function parseStdout(stdout: string): string[] {
   if (errorLabel.test(stdout)) {
     throw new Error('Maven output contains errors.');
   }
-  const digraphs = stdout.replace(logLabel, '').match(digraph);
+  const withoutLabels = stdout.replace(logLabel, '');
+  const digraphs = parseDigraph(withoutLabels);
   if (!digraphs) {
     throw new Error('Cannot find any digraphs.');
   }

--- a/tests/fixtures/parse-digraph/output-without-labels-with-env-var.txt
+++ b/tests/fixtures/parse-digraph/output-without-labels-with-env-var.txt
@@ -1,0 +1,18 @@
+Scanning for projects...
+
+------------------------------------------------------------------------
+Building Spring Boot Quartz Starter 2.0.0.BUILD-SNAPSHOT
+------------------------------------------------------------------------
+
+--- maven-dependency-plugin:2.10:tree (default-cli) @ spring-boot-starter-quartz ---
+digraph "com.snyk.platform:tester-service:jar:${my.version}" {
+"com.snyk.platform:tester-service:jar:${my.version}" -> "com.snyk.tester:tester-queue:jar:15.0.0:compile" ;
+"com.snyk.platform:tester-service:jar:${my.version}" -> "com.snyk.tester:tester-queue:test-jar:tests:15.0.0:test" ;
+}
+------------------------------------------------------------------------
+BUILD SUCCESS
+------------------------------------------------------------------------
+Total time: 1.956 s
+Finished at: 2017-06-19T14:28:14+03:00
+Final Memory: 23M/331M
+------------------------------------------------------------------------

--- a/tests/fixtures/parse-digraph/output-without-labels.txt
+++ b/tests/fixtures/parse-digraph/output-without-labels.txt
@@ -1,0 +1,18 @@
+Scanning for projects...
+
+------------------------------------------------------------------------
+Building Spring Boot Quartz Starter 2.0.0.BUILD-SNAPSHOT
+------------------------------------------------------------------------
+
+--- maven-dependency-plugin:2.10:tree (default-cli) @ spring-boot-starter-quartz ---
+digraph "com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" {
+"com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" -> "com.snyk.tester:tester-queue:jar:15.0.0:compile" ;
+"com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" -> "com.snyk.tester:tester-queue:test-jar:tests:15.0.0:test" ;
+}
+------------------------------------------------------------------------
+BUILD SUCCESS
+------------------------------------------------------------------------
+Total time: 1.956 s
+Finished at: 2017-06-19T14:28:14+03:00
+Final Memory: 23M/331M
+------------------------------------------------------------------------

--- a/tests/fixtures/parse-mvn/with-warnings-and-env-var.txt
+++ b/tests/fixtures/parse-mvn/with-warnings-and-env-var.txt
@@ -1,0 +1,36 @@
+[INFO] Scanning for projects...
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.example:my-app:jar:${env.randomenv1}
+[WARNING] 'version' contains an expression but should be a constant. @ line 7, column 12
+[WARNING] 
+[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
+[WARNING] 
+[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
+[WARNING] 
+[INFO] 
+[INFO] -------------------------< com.example:my-app >-------------------------
+[INFO] Building my-app ${env.randomenv1}
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ my-app ---
+[INFO] digraph "com.example:my-app:jar:${env.randomenv1}" { 
+[INFO]  "com.example:my-app:jar:${env.randomenv1}" -> "org.apache.poi:poi:jar:5.2.0:compile" ; 
+[INFO]  "com.example:my-app:jar:${env.randomenv1}" -> "org.apache.poi:poi-ooxml:jar:5.2.0:compile" ; 
+[INFO]  "org.apache.poi:poi:jar:5.2.0:compile" -> "commons-codec:commons-codec:jar:1.15:compile" ; 
+[INFO]  "org.apache.poi:poi:jar:5.2.0:compile" -> "org.apache.commons:commons-collections4:jar:4.4:compile" ; 
+[INFO]  "org.apache.poi:poi:jar:5.2.0:compile" -> "org.apache.commons:commons-math3:jar:3.6.1:compile" ; 
+[INFO]  "org.apache.poi:poi:jar:5.2.0:compile" -> "commons-io:commons-io:jar:2.11.0:compile" ; 
+[INFO]  "org.apache.poi:poi:jar:5.2.0:compile" -> "com.zaxxer:SparseBitSet:jar:1.2:compile" ; 
+[INFO]  "org.apache.poi:poi:jar:5.2.0:compile" -> "org.apache.logging.log4j:log4j-api:jar:2.17.1:compile" ; 
+[INFO]  "org.apache.poi:poi-ooxml:jar:5.2.0:compile" -> "org.apache.poi:poi-ooxml-lite:jar:5.2.0:compile" ; 
+[INFO]  "org.apache.poi:poi-ooxml:jar:5.2.0:compile" -> "org.apache.xmlbeans:xmlbeans:jar:5.0.3:compile" ; 
+[INFO]  "org.apache.poi:poi-ooxml:jar:5.2.0:compile" -> "org.apache.commons:commons-compress:jar:1.21:compile" ; 
+[INFO]  "org.apache.poi:poi-ooxml:jar:5.2.0:compile" -> "com.github.virtuald:curvesapi:jar:1.06:compile" ; 
+[INFO]  "org.apache.xmlbeans:xmlbeans:jar:5.0.3:compile" -> "xml-apis:xml-apis:jar:1.4.01:compile" ; 
+[INFO]  } 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  0.867 s
+[INFO] Finished at: 2023-04-05T14:05:31+01:00
+[INFO] ------------------------------------------------------------------------

--- a/tests/functional/parse-digraph.test.ts
+++ b/tests/functional/parse-digraph.test.ts
@@ -1,0 +1,25 @@
+import * as test from 'tap-only';
+import { parseDigraph } from '../../lib/parse-digraph';
+import { readFixture } from '../helpers/read';
+
+test('parse valid input to expected string', async (t) => {
+  const input = await readFixture('parse-digraph/output-without-labels.txt');
+  const result = parseDigraph(input);
+  const expected = `digraph "com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" {
+"com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" -> "com.snyk.tester:tester-queue:jar:15.0.0:compile" ;
+"com.snyk.platform:tester-service:jar:4.0.5-SNAPSHOT" -> "com.snyk.tester:tester-queue:test-jar:tests:15.0.0:test" ;
+}`;
+  t.equals(result?.[0], expected);
+});
+
+test('parse valid input with env vars to expected string', async (t) => {
+  const input = await readFixture(
+    'parse-digraph/output-without-labels-with-env-var.txt',
+  );
+  const result = parseDigraph(input);
+  const expected = `digraph "com.snyk.platform:tester-service:jar:\${my.version}" {
+"com.snyk.platform:tester-service:jar:\${my.version}" -> "com.snyk.tester:tester-queue:jar:15.0.0:compile" ;
+"com.snyk.platform:tester-service:jar:\${my.version}" -> "com.snyk.tester:tester-queue:test-jar:tests:15.0.0:test" ;
+}`;
+  t.equals(result?.[0], expected);
+});

--- a/tests/functional/parse-mvn.test.ts
+++ b/tests/functional/parse-mvn.test.ts
@@ -104,3 +104,18 @@ test('parseVersions from mvn --version', async (t) => {
     t.fail('result.data.dependencies was empty');
   }
 });
+
+test('parse output with WARNINGS and env var', async (t) => {
+  const mavenOutput = await readFixture(
+    'parse-mvn/with-warnings-and-env-var.txt',
+  );
+  const depTree = parseTree(mavenOutput, false);
+  t.ok(
+    depTree.package.dependencies?.['org.apache.poi:poi'],
+    'org.apache.poi:poi is top level dep',
+  );
+  t.ok(
+    depTree.package.dependencies?.['org.apache.poi:poi-ooxml'],
+    'org.apache.poi:poi-ooxml is top level dep',
+  );
+});

--- a/tests/functional/stdout.test.ts
+++ b/tests/functional/stdout.test.ts
@@ -26,7 +26,7 @@ const singleProjectDigraph = `digraph "io.snyk:single-project:jar:0.0.1-SNAPSHOT
 "org.springframework:spring-web:jar:5.3.20:compile" -> "org.springframework:spring-beans:jar:5.3.20:compile" ; 
 "org.springframework:spring-web:jar:5.3.20:compile" -> "org.springframework:spring-core:jar:5.3.20:compile" ; 
 "org.springframework:spring-core:jar:5.3.20:compile" -> "org.springframework:spring-jcl:jar:5.3.20:compile" ; 
-}`;
+} `;
 
 test('parseStdout single project', async (t) => {
   const received = parseStdout(singleProjectStdout);
@@ -115,12 +115,12 @@ const multiProjectStdout = `[INFO] Scanning for projects...
 [INFO] ------------------------------------------------------------------------`;
 
 const rootProjectDigraph = `digraph "io.snyk:aggregate-project:pom:1.0.0" { 
-}`;
+} `;
 
 const coreProjectDigraph = `digraph "io.snyk:core:jar:1.0.0" { 
 "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ; 
 "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ; 
-}`;
+} `;
 
 const webProjectDigraph = `digraph "io.snyk:web:jar:1.0.0" { 
 "io.snyk:web:jar:1.0.0" -> "io.snyk:core:jar:1.0.0:compile" ; 
@@ -130,7 +130,7 @@ const webProjectDigraph = `digraph "io.snyk:web:jar:1.0.0" {
 "org.springframework:spring-web:jar:5.3.21:compile" -> "org.springframework:spring-beans:jar:5.3.21:compile" ; 
 "org.springframework:spring-web:jar:5.3.21:compile" -> "org.springframework:spring-core:jar:5.3.21:compile" ; 
 "org.springframework:spring-core:jar:5.3.21:compile" -> "org.springframework:spring-jcl:jar:5.3.21:compile" ; 
-}`;
+} `;
 
 test('parseStdout multi project', async (t) => {
   const received = parseStdout(multiProjectStdout);


### PR DESCRIPTION
Fixing bug when mvn output contains unresolved properties, i.e.
'${my.prop}'.