### PR TITLE
feat: find jars recursively by default

### DIFF
--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -113,10 +113,10 @@ export function isArchive(file: string): boolean {
   return !!file.match(/\.(([jwa]ar)|(zip))$/);
 }
 
-export function findArchives(targetPath: string, recursive = false): string[] {
+export function findArchives(targetPath: string): string[] {
   const stats = fs.statSync(targetPath);
   const dir = stats.isFile() ? path.dirname(targetPath) : targetPath;
-  return glob.sync(`${dir}/${recursive ? '**/' : ''}*.@(jar|war|aar|zip)`);
+  return glob.sync(`${dir}/**/*.@(jar|war|aar|zip)`);
 }
 
 function getRootDependency(root: string, targetFile?: string): MavenPackage {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -136,8 +136,7 @@ export async function inspect(
   }
 
   if (options.scanAllUnmanaged) {
-    const recursive = !!options.allProjects;
-    const archives = findArchives(root, recursive);
+    const archives = findArchives(root);
     if (archives.length > 0) {
       debug(`Creating dep-graph from archives in ${root}`);
       const depGraph = await createDepGraphFromArchives(

--- a/tests/functional/archive.test.ts
+++ b/tests/functional/archive.test.ts
@@ -33,18 +33,15 @@ test('findArchives', async (t) => {
   [
     { dir: springCorePath, expectedNumOfJars: 1 },
     { dir: badPath, expectedNumOfJars: 2 },
-    { dir: fixturesPath, expectedNumOfJars: 0 },
+    { dir: fixturesPath, expectedNumOfJars: 13 },
     { dir: dummyPath, expectedNumOfJars: 0 },
-    { dir: nestedJarsPath, expectedNumOfJars: 1 },
-    { dir: nestedJarsPath, expectedNumOfJars: 2, recursive: true },
-    { dir: nestedWarsAarsPath, expectedNumOfJars: 2, recursive: true },
-  ].forEach(({ dir, expectedNumOfJars, recursive }) =>
+    { dir: nestedJarsPath, expectedNumOfJars: 2 },
+    { dir: nestedWarsAarsPath, expectedNumOfJars: 2 },
+  ].forEach(({ dir, expectedNumOfJars }) =>
     t.same(
-      findArchives(dir, recursive).length,
+      findArchives(dir).length,
       expectedNumOfJars,
-      `should find ${expectedNumOfJars} jars for "${path.basename(dir)}" ${
-        recursive ? '(recursive)' : ''
-      }`,
+      `should find ${expectedNumOfJars} jars for "${path.basename(dir)}"`,
     ),
   );
 });


### PR DESCRIPTION
To avoid confusion with --scan-all-unmanaged and --all-projects, simply scan all jars any levels deep by default.