### PR TITLE
Feat: [OSM-568] include test scope deps in compile scope chain

### DIFF
--- a/tests/functional/dep-graph.test.ts
+++ b/tests/functional/dep-graph.test.ts
@@ -19,7 +19,7 @@ test('buildDepGraph for compile transitives under test deps', async (t) => {
         dependsOn: ['compile:d:jar:1.0.0:compile'],
       },
       'compile:c:jar:1.0.0:compile': {
-        dependsOn: [],
+        dependsOn: ['test:a:jar:1.0.0:test'],
       },
       'compile:d:jar:1.0.0:compile': {
         dependsOn: [],
@@ -107,12 +107,26 @@ test('buildDepGraph for compile transitives under test deps', async (t) => {
           {
             nodeId: 'compile:c:jar:1.0.0:compile',
             pkgId: 'compile:c@1.0.0',
-            deps: [],
+            deps: [
+              {
+                nodeId: 'test:a:jar:1.0.0:test:pruned'
+              }
+            ],
           },
           {
             nodeId: 'compile:d:jar:1.0.0:compile',
             pkgId: 'compile:d@1.0.0',
             deps: [],
+          },
+          {
+            nodeId: 'test:a:jar:1.0.0:test:pruned',
+            pkgId: 'test:a@1.0.0',
+            deps: [],
+            info: {
+              labels: {
+                pruned: 'true',
+              },
+            },
           },
         ],
       },


### PR DESCRIPTION
#### What does this PR do?

Adds a method that peaks through the test branches in search for a compile transitive.


#### Any background context you want to provide?

Any pom with 2 deps that pull in same transitive at same level, first put the test dep and then the compile one. This will make `mvn dependency:tree` to output some compile transitives under the test dep, so, the outputed DepGraph will be missing some compile deps.

#### What are the relevant tickets?

#### Screenshots

Performance tests:

---------------- Clients pom.xml ----------------

new:                     2.115ms

prev:                     1.896ms



new vs prev                                 11.54% slower than prev


---------------- Large pom.xml ----------------

new:                     2.599ms

prev:                    2.348ms


new vs prev                                 10.68% slower than prev

[SUP-1187]: https://snyksec.atlassian.net/browse/SUP-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ