### PR TITLE
feat: Keep `test` scoped deps that transitively reach prod-like deps

### DIFF
--- a/lib/parse/types.ts
+++ b/lib/parse/types.ts
@@ -56,4 +56,6 @@ export interface GetPackageData {
 
 export interface MavenGraphNode {
   dependsOn: string[];
+  parents: string[];
+  reachesProdDep: boolean;
 }

--- a/tests/functional/digraph.test.ts
+++ b/tests/functional/digraph.test.ts
@@ -1,9 +1,9 @@
 import { test } from 'tap';
 import { parseDigraphs } from '../../lib/parse/digraph';
 
-const core = `digraph "io.snyk:core:jar:1.0.0" { 
-"io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ; 
-"io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ; 
+const core = `digraph "io.snyk:core:jar:1.0.0" {
+"io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ;
+"io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ;
 }`;
 
 test('parses digraph', async (t) => {
@@ -18,12 +18,18 @@ test('parses digraph', async (t) => {
               'org.apache.logging.log4j:log4j-api:jar:2.17.2:compile',
               'org.apache.logging.log4j:log4j-core:jar:2.17.2:compile',
             ],
+            parents: [],
+            reachesProdDep: true,
           },
           'org.apache.logging.log4j:log4j-api:jar:2.17.2:compile': {
             dependsOn: [],
+            parents: ['io.snyk:core:jar:1.0.0'],
+            reachesProdDep: true,
           },
           'org.apache.logging.log4j:log4j-core:jar:2.17.2:compile': {
             dependsOn: [],
+            parents: ['io.snyk:core:jar:1.0.0'],
+            reachesProdDep: true,
           },
         },
       },
@@ -32,9 +38,9 @@ test('parses digraph', async (t) => {
   );
 });
 
-const badRoot = `digraph bad { 
-  "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ; 
-  "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ; 
+const badRoot = `digraph bad {
+  "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile" ;
+  "io.snyk:core:jar:1.0.0" -> "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile" ;
 }`;
 test('could not find root node', async (t) => {
   try {
@@ -53,7 +59,7 @@ test('could not find root node', async (t) => {
   }
 });
 
-const badDependency = `digraph "io.snyk:core:jar:1.0.0" { 
+const badDependency = `digraph "io.snyk:core:jar:1.0.0" {
 bad
 }`;
 

--- a/tests/functional/maven-graph-builder.test.ts
+++ b/tests/functional/maven-graph-builder.test.ts
@@ -10,6 +10,8 @@ test('default constructor', async (t) => {
       nodes: {
         root: {
           dependsOn: [],
+          parents: [],
+          reachesProdDep: false,
         },
       },
     },
@@ -28,12 +30,18 @@ test('connect nodes', async (t) => {
       nodes: {
         root: {
           dependsOn: ['a'],
+          parents: [],
+          reachesProdDep: true,
         },
         a: {
           dependsOn: ['b'],
+          parents: ['root'],
+          reachesProdDep: true,
         },
         b: {
           dependsOn: [],
+          parents: ['a'],
+          reachesProdDep: true,
         },
       },
     },
@@ -53,9 +61,13 @@ test('skips duplicate connections', async (t) => {
       nodes: {
         root: {
           dependsOn: ['a'],
+          parents: [],
+          reachesProdDep: true,
         },
         a: {
           dependsOn: [],
+          parents: ['root'],
+          reachesProdDep: true,
         },
       },
     },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This is a workaround to deal with how Maven dependency:tree outputs dependency information. Prod-like dependencies are not shown again if first seen via a test scoped dependency.

This change ensures that we keep any prod-like dependencies that are first seen through a test scope dependency.

A side-effect is that some `test` scoped dependencies will be included in the dep-graph even when `test` scoped deps are explicitly excluded.


Update: `mvn dependency:tree` does not output any `provided` or `system` transitives, so we should not do anything in that case.
