### PR TITLE
fix: [SUP-2210] do dot fail parsing when there is build success

### DIFF
--- a/lib/parse/stdout.ts
+++ b/lib/parse/stdout.ts
@@ -2,10 +2,11 @@ import { parseDigraph } from '../parse-digraph';
 
 const logLabel = /^\[\w+\]\s*/gm;
 const errorLabel = /^\[ERROR\]/gm;
+const successLabel = /^\[INFO\] BUILD SUCCESS/gm;
 
 // Parse the output from 'mvn dependency:tree -DoutputType=dot'
 export function parseStdout(stdout: string): string[] {
-  if (errorLabel.test(stdout)) {
+  if (errorLabel.test(stdout) && !successLabel.test(stdout)) {
     throw new Error('Maven output contains errors.');
   }
   const withoutLabels = stdout.replace(logLabel, '');

--- a/tests/fixtures/successful-build-with-error-log/expected-dep-graph.json
+++ b/tests/fixtures/successful-build-with-error-log/expected-dep-graph.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "io.snyk.example:test-project@1.0.0-SNAPSHOT",
+      "info": {
+        "name": "io.snyk.example:test-project",
+        "version": "1.0.0-SNAPSHOT"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "io.snyk.example:test-project@1.0.0-SNAPSHOT",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/tests/fixtures/successful-build-with-error-log/pom.xml
+++ b/tests/fixtures/successful-build-with-error-log/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.snyk.example</groupId>
+    <artifactId>test-project</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>test-project</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-error-without-failing-build</id>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>9000.1</version>
+                                    <message>[ERROR] Always ERROR</message>
+                                </requireMavenVersion>
+                            </rules>
+                            <fail>false</fail>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/functional/stdout.test.ts
+++ b/tests/functional/stdout.test.ts
@@ -145,6 +145,26 @@ const errorStdout = `[INFO] Scanning for projects...
 [ERROR] [ERROR] Some problems were encountered while processing the POMs:
 `;
 
+const buildSuccessErrorLogStdout = `[INFO] Scanning for projects...
+[INFO] 
+[INFO] --------------------< io.snyk.example:test-project >--------------------
+[INFO] Building test-project 1.0.0-SNAPSHOT
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-enforcer-plugin:3.4.1:enforce (enforce-error-without-failing-build) @ test-project ---
+[WARNING] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion failed with message:
+[ERROR] Always ERROR
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ test-project ---
+[INFO] No sources to compile
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  0.567 s
+[INFO] Finished at: 2023-11-29T15:29:55+02:00
+[INFO] ------------------------------------------------------------------------
+`;
+
 test('output contains errors', async (t) => {
   try {
     parseStdout(errorStdout);
@@ -154,6 +174,23 @@ test('output contains errors', async (t) => {
       t.equals(
         err.message,
         'Maven output contains errors.',
+        'throws expected error',
+      );
+    } else {
+      t.fail('expected err to be instanceof Error');
+    }
+  }
+});
+
+test('output contains error, but succeeds building', async (t) => {
+  try {
+    const received = parseStdout(buildSuccessErrorLogStdout);
+    t.fail('expected error to be thrown');
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      t.equals(
+        err.message,
+        'Cannot find any digraphs.',
         'throws expected error',
       );
     } else {

--- a/tests/system/plugin.test.ts
+++ b/tests/system/plugin.test.ts
@@ -197,6 +197,29 @@ test('inspect on pom with bad dependency', async (t) => {
   }
 });
 
+test('inspect on pom that logs an error but succeeds', async (t) => {
+  const result = await plugin.inspect(
+    __dirname,
+    path.join('..', 'fixtures', 'successful-build-with-error-log', 'pom.xml'),
+    {});
+
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+
+  t.strictEqual(result.scannedProjects.length, 1, 'returns 1 scanned project');
+  const expectedJSON = await readFixtureJSON(
+    'successful-build-with-error-log',
+    'expected-dep-graph.json',
+  );
+  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
+  console.log(JSON.stringify(result.scannedProjects[0].depGraph));
+  t.ok(
+    result.scannedProjects[0].depGraph?.equals(expectedDepGraph),
+    'returns expected dep-graph',
+  );
+});
+
 test('inspect on mvn error', async (t) => {
   const targetFile = path.join(fixturesPath, 'bad', 'pom.xml');
   const fullCommand = `mvn dependency:tree -DoutputType=dot --batch-mode --non-recursive --file="${targetFile}"`;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This PR enables other plugins to log out errors without the snyk plugin throwing an error. There are cases where another plugin might log an error, but not fail the build - since some plugins might run as part of generating the dependency tree, we need to ignore those if the build overall was successful.