### PR TITLE
fix: record and use visited dependency information

### DIFF
--- a/tests/tap/functional/dep-graph.test.ts
+++ b/tests/tap/functional/dep-graph.test.ts
@@ -1,4 +1,4 @@
-import tap from 'tap';
+import * as tap from 'tap';
 import { parseDigraphs } from '../../../lib/parse/digraph';
 import { buildDepGraph } from '../../../lib/parse/dep-graph';
 
@@ -19,7 +19,7 @@ test('buildDepGraph', async (t) => {
     "test:root:jar:1.2.3" -> "test:d:jar:1.0.0" ;
     "test:a:jar:1.0.0" -> "test:b:jar:1.0.0" ;
     "test:b:jar:1.0.0" -> "test:a:jar:1.0.0" ; // pruned (cyclic)
-    "test:c:jar:1.0.0" -> "test:d:jar:1.0.0" ; // pruned (first seen at top level)
+    "test:c:jar:1.0.0" -> "test:d:jar:1.0.3" ; // pruned (first seen at top level)
   }`;
   const mavenGraph = parseDigraphs([diGraph])[0];
   const depGraph = buildDepGraph(mavenGraph);


### PR DESCRIPTION
In preparation for supporting -Dverbose the breadth first search needs to retain previously visited dependency information.

At the moment we record whether a dependency has been seen (true/false) based on the maven graph node id. This id contains the dependency version. For example 'com.example:my-app:jar:jdk8:1.2.3:compile'.

However when maven is determining whether a dependency has already been seen only four properties are used:

* groupId
* artifactId
* type
* classifier (optional)

These are the properties that uniquely identify a dependency in Maven.

Changing visited to be keyed by these four properties instead.

In addition we then record the parsed dependency for these visited dependencies so that we can use that information when adding and connecting the dep-graph nodes.

The effect is that if a duplicate node is found, the previously visited version is preferred regardless of what the duplicate node is set to.

This doesn't really effect the current implementation because maven-dependency-plugin hides duplicates. Another PR will start to support -Dverbose where this becomes important that we select the effective version being resolved by Maven.