### PR TITLE
feat: support verbose

### DIFF
--- a/lib/parse/digraph.ts
+++ b/lib/parse/digraph.ts
@@ -44,5 +44,19 @@ function findQuotedContents(value?: string): string | null {
   if (!value) return null;
   const start = value.indexOf('"') + 1;
   const end = value.lastIndexOf('"');
+  // when using -Dverbose ensure omitted reasons are parsed correctly
+  // https://github.com/apache/maven/blob/ab6ec5bd74af20ab429509eb56fc8e3dff4c7fc7/maven-core/src/main/java/org/apache/maven/internal/impl/DefaultNode.java#L113
+  if (value.indexOf('omitted for conflict with') > -1) {
+    const [left] = value
+      .substring(start + 1, end)
+      .split(' - omitted for conflict with ');
+    return left;
+  }
+  if (value.indexOf('omitted for duplicate') > -1) {
+    const [left] = value
+      .substring(start + 1, end)
+      .split(' - omitted for duplicate');
+    return left;
+  }
   return value.substring(start, end);
 }

--- a/lib/parse/index.ts
+++ b/lib/parse/index.ts
@@ -7,12 +7,17 @@ import { buildDepGraph } from './dep-graph';
 export function parse(
   stdout: string,
   includeTestScope = false,
+  verboseEnabled = false,
 ): { scannedProjects: ScannedProject[] } {
   const digraphs = parseStdout(stdout);
   const mavenGraphs = parseDigraphs(digraphs);
   const scannedProjects: ScannedProject[] = [];
   for (const mavenGraph of mavenGraphs) {
-    const depGraph = buildDepGraph(mavenGraph, includeTestScope);
+    const depGraph = buildDepGraph(
+      mavenGraph,
+      includeTestScope,
+      verboseEnabled,
+    );
     scannedProjects.push({ depGraph });
   }
   return {

--- a/tests/fixtures/complex-aggregate-project/verbose-scan-result.json
+++ b/tests/fixtures/complex-aggregate-project/verbose-scan-result.json
@@ -1,0 +1,238 @@
+{
+    "scannedProjects": [
+      {
+        "depGraph": {
+          "schemaVersion": "1.2.0",
+          "pkgManager": {
+            "name": "maven"
+          },
+          "pkgs": [
+            {
+              "id": "io.snyk:aggregate-project@1.0.0",
+              "info": {
+                "name": "io.snyk:aggregate-project",
+                "version": "1.0.0"
+              }
+            }
+          ],
+          "graph": {
+            "rootNodeId": "root-node",
+            "nodes": [
+              {
+                "nodeId": "root-node",
+                "pkgId": "io.snyk:aggregate-project@1.0.0",
+                "deps": []
+              }
+            ]
+          }
+        }
+      },
+      {
+        "depGraph": {
+          "schemaVersion": "1.2.0",
+          "pkgManager": {
+            "name": "maven"
+          },
+          "pkgs": [
+            {
+              "id": "io.snyk:core@1.0.0",
+              "info": {
+                "name": "io.snyk:core",
+                "version": "1.0.0"
+              }
+            },
+            {
+              "id": "org.apache.logging.log4j:log4j-api@2.17.2",
+              "info": {
+                "name": "org.apache.logging.log4j:log4j-api",
+                "version": "2.17.2"
+              }
+            },
+            {
+              "id": "org.apache.logging.log4j:log4j-core@2.17.2",
+              "info": {
+                "name": "org.apache.logging.log4j:log4j-core",
+                "version": "2.17.2"
+              }
+            }
+          ],
+          "graph": {
+            "rootNodeId": "root-node",
+            "nodes": [
+              {
+                "nodeId": "root-node",
+                "pkgId": "io.snyk:core@1.0.0",
+                "deps": [
+                  {
+                    "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+                  },
+                  {
+                    "nodeId": "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile",
+                "pkgId": "org.apache.logging.log4j:log4j-api@2.17.2",
+                "deps": []
+              },
+              {
+                "nodeId": "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile",
+                "pkgId": "org.apache.logging.log4j:log4j-core@2.17.2",
+                "deps": [
+                  {
+                    "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "depGraph": {
+          "schemaVersion": "1.2.0",
+          "pkgManager": {
+            "name": "maven"
+          },
+          "pkgs": [
+            {
+              "id": "io.snyk:web@1.0.0",
+              "info": {
+                "name": "io.snyk:web",
+                "version": "1.0.0"
+              }
+            },
+            {
+              "id": "io.snyk:core@1.0.0",
+              "info": {
+                "name": "io.snyk:core",
+                "version": "1.0.0"
+              }
+            },
+            {
+              "id": "org.springframework:spring-web@5.3.21",
+              "info": {
+                "name": "org.springframework:spring-web",
+                "version": "5.3.21"
+              }
+            },
+            {
+              "id": "org.apache.logging.log4j:log4j-api@2.17.2",
+              "info": {
+                "name": "org.apache.logging.log4j:log4j-api",
+                "version": "2.17.2"
+              }
+            },
+            {
+              "id": "org.apache.logging.log4j:log4j-core@2.17.2",
+              "info": {
+                "name": "org.apache.logging.log4j:log4j-core",
+                "version": "2.17.2"
+              }
+            },
+            {
+              "id": "org.springframework:spring-beans@5.3.21",
+              "info": {
+                "name": "org.springframework:spring-beans",
+                "version": "5.3.21"
+              }
+            },
+            {
+              "id": "org.springframework:spring-core@5.3.21",
+              "info": {
+                "name": "org.springframework:spring-core",
+                "version": "5.3.21"
+              }
+            },
+            {
+              "id": "org.springframework:spring-jcl@5.3.21",
+              "info": {
+                "name": "org.springframework:spring-jcl",
+                "version": "5.3.21"
+              }
+            }
+          ],
+          "graph": {
+            "rootNodeId": "root-node",
+            "nodes": [
+              {
+                "nodeId": "root-node",
+                "pkgId": "io.snyk:web@1.0.0",
+                "deps": [
+                  {
+                    "nodeId": "io.snyk:core:jar:1.0.0:compile"
+                  },
+                  {
+                    "nodeId": "org.springframework:spring-web:jar:5.3.21:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "io.snyk:core:jar:1.0.0:compile",
+                "pkgId": "io.snyk:core@1.0.0",
+                "deps": [
+                  {
+                    "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+                  },
+                  {
+                    "nodeId": "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "org.springframework:spring-web:jar:5.3.21:compile",
+                "pkgId": "org.springframework:spring-web@5.3.21",
+                "deps": [
+                  {
+                    "nodeId": "org.springframework:spring-beans:jar:5.3.21:compile"
+                  },
+                  {
+                    "nodeId": "org.springframework:spring-core:jar:5.3.21:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile",
+                "pkgId": "org.apache.logging.log4j:log4j-api@2.17.2",
+                "deps": []
+              },
+              {
+                "nodeId": "org.apache.logging.log4j:log4j-core:jar:2.17.2:compile",
+                "pkgId": "org.apache.logging.log4j:log4j-core@2.17.2",
+                "deps": [
+                  {
+                    "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "org.springframework:spring-beans:jar:5.3.21:compile",
+                "pkgId": "org.springframework:spring-beans@5.3.21",
+                "deps": [
+                  {
+                    "nodeId": "org.springframework:spring-core:jar:5.3.21:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "org.springframework:spring-core:jar:5.3.21:compile",
+                "pkgId": "org.springframework:spring-core@5.3.21",
+                "deps": [
+                  {
+                    "nodeId": "org.springframework:spring-jcl:jar:5.3.21:compile"
+                  }
+                ]
+              },
+              {
+                "nodeId": "org.springframework:spring-jcl:jar:5.3.21:compile",
+                "pkgId": "org.springframework:spring-jcl@5.3.21",
+                "deps": []
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+  

--- a/tests/fixtures/test-project/expected-verbose-dep-graph.json
+++ b/tests/fixtures/test-project/expected-verbose-dep-graph.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "io.snyk.example:test-project@1.0-SNAPSHOT",
+      "info": {
+        "name": "io.snyk.example:test-project",
+        "version": "1.0-SNAPSHOT"
+      }
+    },
+    {
+      "id": "axis:axis@1.4",
+      "info": {
+        "name": "axis:axis",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-jaxrpc@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-jaxrpc",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-saaj@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-saaj",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "axis:axis-wsdl4j@1.5.1",
+      "info": {
+        "name": "axis:axis-wsdl4j",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "commons-logging:commons-logging@1.0.4",
+      "info": {
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "commons-discovery:commons-discovery@0.2",
+      "info": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "io.snyk.example:test-project@1.0-SNAPSHOT",
+        "deps": [
+          {
+            "nodeId": "axis:axis:jar:1.4:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "axis:axis:jar:1.4:compile",
+        "pkgId": "axis:axis@1.4",
+        "deps": [
+          {
+            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
+          },
+          {
+            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+          },
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+          },
+          {
+            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-saaj@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
+        "pkgId": "axis:axis-wsdl4j@1.5.1",
+        "deps": []
+      },
+      {
+        "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.4",
+        "deps": []
+      },
+      {
+        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
+        "pkgId": "commons-discovery:commons-discovery@0.2",
+        "deps": [
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/verbose-project/expected-verbose-dep-graph.json
+++ b/tests/fixtures/verbose-project/expected-verbose-dep-graph.json
@@ -1,0 +1,498 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "io.snyk.example:verbose-project@1.0-SNAPSHOT",
+      "info": {
+        "name": "io.snyk.example:verbose-project",
+        "version": "1.0-SNAPSHOT"
+      }
+    },
+    {
+      "id": "axis:axis@1.4",
+      "info": {
+        "name": "axis:axis",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-starter@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-starter",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-jaxrpc@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-jaxrpc",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-saaj@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-saaj",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "axis:axis-wsdl4j@1.5.1",
+      "info": {
+        "name": "axis:axis-wsdl4j",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "commons-logging:commons-logging@1.0.4",
+      "info": {
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "commons-discovery:commons-discovery@0.2",
+      "info": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-autoconfigure",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-starter-logging",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "jakarta.annotation:jakarta.annotation-api@1.3.5",
+      "info": {
+        "name": "jakarta.annotation:jakarta.annotation-api",
+        "version": "1.3.5"
+      }
+    },
+    {
+      "id": "org.springframework:spring-core@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-core",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.yaml:snakeyaml@1.30",
+      "info": {
+        "name": "org.yaml:snakeyaml",
+        "version": "1.30"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-core@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-core",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "org.springframework:spring-context@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-context",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-classic@1.2.12",
+      "info": {
+        "name": "ch.qos.logback:logback-classic",
+        "version": "1.2.12"
+      }
+    },
+    {
+      "id": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
+      "info": {
+        "name": "org.apache.logging.log4j:log4j-to-slf4j",
+        "version": "2.17.2"
+      }
+    },
+    {
+      "id": "org.slf4j:jul-to-slf4j@1.7.36",
+      "info": {
+        "name": "org.slf4j:jul-to-slf4j",
+        "version": "1.7.36"
+      }
+    },
+    {
+      "id": "org.springframework:spring-jcl@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-jcl",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-annotations@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-annotations",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "org.springframework:spring-aop@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-aop",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-beans@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-beans",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-expression@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-expression",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-core@1.2.12",
+      "info": {
+        "name": "ch.qos.logback:logback-core",
+        "version": "1.2.12"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.32",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.32"
+      }
+    },
+    {
+      "id": "org.apache.logging.log4j:log4j-api@2.17.2",
+      "info": {
+        "name": "org.apache.logging.log4j:log4j-api",
+        "version": "2.17.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "io.snyk.example:verbose-project@1.0-SNAPSHOT",
+        "deps": [
+          {
+            "nodeId": "axis:axis:jar:1.4:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "axis:axis:jar:1.4:compile",
+        "pkgId": "axis:axis@1.4",
+        "deps": [
+          {
+            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
+          },
+          {
+            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+          },
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+          },
+          {
+            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-starter@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.yaml:snakeyaml:jar:1.30:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.2",
+        "deps": [
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile"
+          },
+          {
+            "nodeId": "org.yaml:snakeyaml:jar:1.30:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-saaj@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
+        "pkgId": "axis:axis-wsdl4j@1.5.1",
+        "deps": []
+      },
+      {
+        "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.4",
+        "deps": []
+      },
+      {
+        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
+        "pkgId": "commons-discovery:commons-discovery@0.2",
+        "deps": [
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-context:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
+        "deps": [
+          {
+            "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile"
+          },
+          {
+            "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile"
+          },
+          {
+            "nodeId": "org.slf4j:jul-to-slf4j:jar:1.7.36:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile",
+        "pkgId": "jakarta.annotation:jakarta.annotation-api@1.3.5",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework:spring-core:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-core@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-jcl:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.yaml:snakeyaml:jar:1.30:compile",
+        "pkgId": "org.yaml:snakeyaml@1.30",
+        "deps": []
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
+        "deps": [
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-core@2.14.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework:spring-context:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-context@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile",
+        "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+        "deps": [
+          {
+            "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile"
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile",
+        "pkgId": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
+          },
+          {
+            "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:jul-to-slf4j:jar:1.7.36:compile",
+        "pkgId": "org.slf4j:jul-to-slf4j@1.7.36",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-jcl:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-jcl@5.3.29",
+        "deps": []
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-annotations@2.14.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-aop@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-beans@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-expression@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile",
+        "pkgId": "ch.qos.logback:logback-core@1.2.12",
+        "deps": []
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.32",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile",
+        "pkgId": "org.apache.logging.log4j:log4j-api@2.17.2",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/tests/fixtures/verbose-project/pom.xml
+++ b/tests/fixtures/verbose-project/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>verbose-project</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>Verbose project</name>
+  <description>Test project for the Maven CLI plugin with omit</description>
+
+  <properties>
+    <axis.version>1.4</axis.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis</artifactId>
+      <version>${axis.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>2.7.15</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.14.2</version>
+    </dependency>
+
+  </dependencies>
+
+
+</project>

--- a/tests/tap/system/plugin.test.ts
+++ b/tests/tap/system/plugin.test.ts
@@ -9,6 +9,7 @@ import * as depGraphLib from '@snyk/dep-graph';
 const testsPath = path.join(__dirname, '../..');
 const fixturesPath = path.join(testsPath, 'fixtures');
 const testProjectPath = path.join(fixturesPath, 'test-project');
+const verboseProjectPath = path.join(fixturesPath, 'verbose-project');
 
 test('inspect on test-project pom', async (t) => {
   const result = await plugin.inspect(
@@ -173,7 +174,7 @@ test('inspect on pom with dependency plugin version less than 2.2', async (t) =>
   }
 });
 
-test('inspect on pom with bad dependency', async (t) => {
+test('inspect on pom with bad dependency using maven 3.5.4', async (t) => {
   try {
     await plugin.inspect('.', path.join(fixturesPath, 'bad', 'pom.xml'), {
       dev: true,
@@ -200,8 +201,14 @@ test('inspect on pom with bad dependency', async (t) => {
 test('inspect on pom that logs an error but succeeds', async (t) => {
   const result = await plugin.inspect(
     __dirname,
-    path.join('../..', 'fixtures', 'successful-build-with-error-log', 'pom.xml'),
-    {});
+    path.join(
+      '../..',
+      'fixtures',
+      'successful-build-with-error-log',
+      'pom.xml',
+    ),
+    {},
+  );
 
   if (!legacyPlugin.isMultiResult(result)) {
     return t.fail('expected multi inspect result');
@@ -347,10 +354,57 @@ test('inspect on aggregate project root pom', async (t) => {
     { name: 'io.snyk:my-app', version: '1.2.3' },
     'has expected root pkg',
   );
-  console.log(result.scannedProjects[0].depGraph?.rootPkg);
   t.equal(
     result.scannedProjects[0].depGraph?.getDepPkgs().length,
     0,
     'root has 0 dependencies',
+  );
+});
+
+test('inspect on test-project pom using -Dverbose', async (t) => {
+  const result = await plugin.inspect(
+    '.',
+    path.join(testProjectPath, 'pom.xml'),
+    {
+      args: ['-Dverbose'],
+    },
+  );
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+  t.equal(result.scannedProjects.length, 1, 'returns 1 scanned project');
+  const expectedJSON = await readFixtureJSON(
+    'test-project',
+    'expected-verbose-dep-graph.json',
+  );
+  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
+  t.same(
+    result.scannedProjects[0].depGraph?.toJSON(),
+    expectedDepGraph.toJSON(),
+    'returns expected dep-graph',
+  );
+});
+
+test('inspect on verbose-project pom using -Dverbose', async (t) => {
+  const result = await plugin.inspect(
+    '.',
+    path.join(verboseProjectPath, 'pom.xml'),
+    {
+      args: ['-Dverbose'],
+    },
+  );
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+  t.equal(result.scannedProjects.length, 1, 'returns 1 scanned project');
+  const expectedJSON = await readFixtureJSON(
+    'verbose-project',
+    'expected-verbose-dep-graph.json',
+  );
+  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
+  t.same(
+    result.scannedProjects[0].depGraph?.toJSON(),
+    expectedDepGraph.toJSON(),
+    'returns expected dep-graph',
   );
 });

--- a/tests/tap/system/reactor.test.ts
+++ b/tests/tap/system/reactor.test.ts
@@ -4,6 +4,7 @@ import tap from 'tap';
 import { legacyPlugin } from '@snyk/cli-interface';
 import * as plugin from '../../../lib';
 import { byPkgName } from '../../helpers/sort';
+import { readFixtureJSON } from '../../helpers/read';
 
 const test = tap.test;
 
@@ -152,4 +153,26 @@ test('inspect on complex aggregate project using maven reactor include test scop
     ].sort(byPkgName),
     'web project has own dependencies, another modules and test dependencies',
   );
+});
+
+test('inspect on complex aggregate project using maven reactor and verbose enabled', async (t) => {
+  const result = await plugin.inspect(
+    path.join(fixturesPath, 'complex-aggregate-project'),
+    'pom.xml',
+    {
+      mavenAggregateProject: true,
+      args: ['-Dverbose']
+    },
+  );
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+  const expectedJSON = await readFixtureJSON(
+    'complex-aggregate-project',
+    'verbose-scan-result.json',
+  );
+  t.equal(result.scannedProjects.length, 3, 'should return 3 scanned projects');
+  t.same(result.scannedProjects[0].depGraph?.toJSON(), expectedJSON.scannedProjects[0].depGraph, 'should return expected scan result');
+  t.same(result.scannedProjects[1].depGraph?.toJSON(), expectedJSON.scannedProjects[1].depGraph, 'should return expected scan result');
+  t.same(result.scannedProjects[2].depGraph?.toJSON(), expectedJSON.scannedProjects[2].depGraph, 'should return expected scan result');
 });


### PR DESCRIPTION
Support passing -Dverbose to resolve omitted dependencies using maven-dependency-plugin.

When verbose is being used execute a specific version of the maven-dependency-plugin. This is becuase on lower version of this plugin outputType=dot is not supported, and it will output a tree.

When verbose is on skip pruning and ensure all dependency lines are traversed fully, using breadth first, first in wins for version resolution.