### PR TITLE
fix: tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,20 @@
 {
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": ".",
-    "pretty": true,
-    "moduleResolution": "node",
-    // https://github.com/tsconfig/bases#node-12-tsconfigjson
-    "target": "es2019",
-    "lib": [
-      "es2019",
-      "es2020.promise",
-      "es2020.bigint",
-      "es2020.string",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "module": "commonjs",
-    "allowJs": true,
-    "sourceMap": true,
-    "resolveJsonModule": true,
-    "strict": true,
-    "noImplicitAny": false, // Needed to compile tap and ansi-escapes
-    "composite": true,
-    "useUnknownInCatchVariables": false,
+      "outDir": "./dist",
+      "pretty": true,
+      "target": "es2022",
+      "lib": [
+        "ES2022",
+      ],
+      "module": "commonjs",
+      "allowJs": true,
+      "sourceMap": true,
+      "strict": true,
+      // "declaration": true,
+      "importHelpers": true,
+      "noImplicitAny": false // Needed to compile tap and ansi-escapes
   },
   "include": [
-    "./lib/**/*"
+      "./lib/**/*"
   ]
 }


### PR DESCRIPTION
changing tsconfig as the one deployed recently with node v18 introduction was breaking the cli.
instead of support es2015/2019 we are introducing es2022