### PR TITLE
feat: support unpruned flag from CLI

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -34,6 +34,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
   mavenAggregateProject?: boolean;
+  unpruned?: boolean;
 }
 
 export function getCommand(root: string, targetFile: string | undefined) {
@@ -158,9 +159,7 @@ export async function inspect(
 
   const mavenCommand = getCommand(root, targetFile);
   const mvnWorkingDirectory = findWrapper(mavenCommand, root, targetPath);
-  const args = options.args || [];
-  const verboseEnabled =
-    args.includes('-Dverbose') || args.includes('-Dverbose=true');
+  const verboseEnabled = handleVerbose(options);
   const mvnArgs = buildArgs(
     root,
     mvnWorkingDirectory,
@@ -260,4 +259,15 @@ export function buildArgs(
   }
 
   return args;
+}
+
+function handleVerbose(options): boolean {
+  const args = options.args || [];
+  const verboseFlag =
+    args.includes('-Dverbose') || args.includes('-Dverbose=true');
+  if (options.unpruned && !verboseFlag) {
+    args.push('-Dverbose');
+    options.args = args;
+  }
+  return verboseFlag || options.unpruned;
 }

--- a/tests/tap/system/plugin.test.ts
+++ b/tests/tap/system/plugin.test.ts
@@ -408,3 +408,27 @@ test('inspect on verbose-project pom using -Dverbose', async (t) => {
     'returns expected dep-graph',
   );
 });
+
+test('inspect on test-project pom using --unpruned', async (t) => {
+  const result = await plugin.inspect(
+    '.',
+    path.join(testProjectPath, 'pom.xml'),
+    {
+      unpruned: true,
+    },
+  );
+  if (!legacyPlugin.isMultiResult(result)) {
+    return t.fail('expected multi inspect result');
+  }
+  t.equal(result.scannedProjects.length, 1, 'returns 1 scanned project');
+  const expectedJSON = await readFixtureJSON(
+    'test-project',
+    'expected-verbose-dep-graph.json',
+  );
+  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
+  t.same(
+    result.scannedProjects[0].depGraph?.toJSON(),
+    expectedDepGraph.toJSON(),
+    'returns expected dep-graph',
+  );
+});


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Given the flag `unpruned` is passed from the CLI - we want to habdle it as if `-Dverbose` was passed as an argument to maven.

#### Where should the reviewer start?
See https://github.com/snyk/cli/pull/5128