### PR TITLE
fix: Cyclic deps support for dverbose

### DIFF
--- a/tests/fixtures/dverbose-project/expected-dverbose-dep-graph.json
+++ b/tests/fixtures/dverbose-project/expected-dverbose-dep-graph.json
@@ -1,0 +1,552 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "com.example:my-java-project@1.0-SNAPSHOT",
+      "info": {
+        "name": "com.example:my-java-project",
+        "version": "1.0-SNAPSHOT"
+      }
+    },
+    {
+      "id": "org.apache.zookeeper:zookeeper@3.9.2",
+      "info": {
+        "name": "org.apache.zookeeper:zookeeper",
+        "version": "3.9.2"
+      }
+    },
+    {
+      "id": "org.apache.zookeeper:zookeeper-jute@3.9.2",
+      "info": {
+        "name": "org.apache.zookeeper:zookeeper-jute",
+        "version": "3.9.2"
+      }
+    },
+    {
+      "id": "org.apache.yetus:audience-annotations@0.12.0",
+      "info": {
+        "name": "org.apache.yetus:audience-annotations",
+        "version": "0.12.0"
+      }
+    },
+    {
+      "id": "io.netty:netty-handler@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-handler",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-transport-native-epoll@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-transport-native-epoll",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+      "info": {
+        "name": "io.netty:netty-tcnative-boringssl-static",
+        "version": "2.0.61.Final"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.30",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.30"
+      }
+    },
+    {
+      "id": "commons-io:commons-io@2.11.0",
+      "info": {
+        "name": "commons-io:commons-io",
+        "version": "2.11.0"
+      }
+    },
+    {
+      "id": "io.netty:netty-common@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-common",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-resolver@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-resolver",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-buffer@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-buffer",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-transport@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-transport",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-transport-native-unix-common@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-transport-native-unix-common",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-codec@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-codec",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-transport-classes-epoll@4.1.105.Final",
+      "info": {
+        "name": "io.netty:netty-transport-classes-epoll",
+        "version": "4.1.105.Final"
+      }
+    },
+    {
+      "id": "io.netty:netty-tcnative-classes@2.0.61.Final",
+      "info": {
+        "name": "io.netty:netty-tcnative-classes",
+        "version": "2.0.61.Final"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "com.example:my-java-project@1.0-SNAPSHOT",
+        "deps": [
+          {
+            "nodeId": "org.apache.zookeeper:zookeeper:jar:3.9.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.zookeeper:zookeeper:jar:3.9.2:compile",
+        "pkgId": "org.apache.zookeeper:zookeeper@3.9.2",
+        "deps": [
+          {
+            "nodeId": "org.apache.zookeeper:zookeeper-jute:jar:3.9.2:compile"
+          },
+          {
+            "nodeId": "org.apache.yetus:audience-annotations:jar:0.12.0:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-handler:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.30:compile"
+          },
+          {
+            "nodeId": "commons-io:commons-io:jar:2.11.0:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.zookeeper:zookeeper-jute:jar:3.9.2:compile",
+        "pkgId": "org.apache.zookeeper:zookeeper-jute@3.9.2",
+        "deps": [
+          {
+            "nodeId": "org.apache.yetus:audience-annotations:jar:0.12.0:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.yetus:audience-annotations:jar:0.12.0:compile",
+        "pkgId": "org.apache.yetus:audience-annotations@0.12.0",
+        "deps": []
+      },
+      {
+        "nodeId": "io.netty:netty-handler:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-handler@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-resolver:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport-native-unix-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-codec:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-transport-native-epoll@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport-native-unix-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport-classes-epoll:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-tcnative-classes:jar:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.30:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.30",
+        "deps": []
+      },
+      {
+        "nodeId": "commons-io:commons-io:jar:2.11.0:compile",
+        "pkgId": "commons-io:commons-io@2.11.0",
+        "deps": []
+      },
+      {
+        "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-common@4.1.105.Final",
+        "deps": []
+      },
+      {
+        "nodeId": "io.netty:netty-resolver:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-resolver@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-buffer@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-transport@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-resolver:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport-native-unix-common:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-transport-native-unix-common@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-codec:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-codec@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-transport-classes-epoll:jar:4.1.105.Final:compile",
+        "pkgId": "io.netty:netty-transport-classes-epoll@4.1.105.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-common:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-buffer:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport:jar:4.1.105.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-transport-native-unix-common:jar:4.1.105.Final:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-classes:jar:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-classes@2.0.61.Final",
+        "deps": []
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile:pruned-cycle"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile:pruned-cycle"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile:pruned-cycle"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile:pruned-cycle"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile:pruned-cycle"
+          },
+          {
+            "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile:pruned-cycle"
+          }
+        ]
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.61.Final:compile:pruned-cycle",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "cyclic"
+          }
+        }
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.61.Final:compile:pruned-cycle",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "cyclic"
+          }
+        }
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.61.Final:compile:pruned-cycle",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "cyclic"
+          }
+        }
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.61.Final:compile:pruned-cycle",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "cyclic"
+          }
+        }
+      },
+      {
+        "nodeId": "io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.61.Final:compile:pruned-cycle",
+        "pkgId": "io.netty:netty-tcnative-boringssl-static@2.0.61.Final",
+        "deps": [],
+        "info": {
+          "labels": {
+            "pruned": "cyclic"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/dverbose-project/pom.xml
+++ b/tests/fixtures/dverbose-project/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-java-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.9.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/jest/system/dverbose-flag.spec.ts
+++ b/tests/jest/system/dverbose-flag.spec.ts
@@ -1,0 +1,30 @@
+import * as plugin from "../../../lib";
+import * as path from 'path';
+import { readFixtureJSON } from '../../helpers/read';
+import * as depGraphLib from '@snyk/dep-graph';
+
+
+const testsPath = path.join(__dirname, '../..');
+const fixturesPath = path.join(testsPath, 'fixtures');
+const testProjectPath = path.join(fixturesPath, 'dverbose-project');
+
+test('inspect on dverbose-project pom using -Dverbose', async () => {
+    let result: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testProjectPath, 'pom.xml'),
+      {
+        args: ['-Dverbose'],
+      },
+    );
+
+    const expectedJSON = await readFixtureJSON(
+      'dverbose-project',
+      'expected-dverbose-dep-graph.json',
+    );
+    const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
+    result = result.scannedProjects[0].depGraph?.toJSON();
+
+    expect(result).toEqual(expectedDepGraph);
+  },
+  10000,
+);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Cyclic dependencies were not handled until now while using the -Dverbose flag. The PR is adding support for cyclic dependencies by keeping track of the already visited packages and storing them in an ancestry list.

