### PR TITLE
Hotfix/dverbose revert v3.4.0

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -34,7 +34,6 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
   mavenAggregateProject?: boolean;
-  unpruned?: boolean;
 }
 
 export function getCommand(root: string, targetFile: string | undefined) {
@@ -159,7 +158,9 @@ export async function inspect(
 
   const mavenCommand = getCommand(root, targetFile);
   const mvnWorkingDirectory = findWrapper(mavenCommand, root, targetPath);
-  const verboseEnabled = handleVerbose(options);
+  const args = options.args || [];
+  const verboseEnabled =
+    args.includes('-Dverbose') || args.includes('-Dverbose=true');
   const mvnArgs = buildArgs(
     root,
     mvnWorkingDirectory,
@@ -259,15 +260,4 @@ export function buildArgs(
   }
 
   return args;
-}
-
-function handleVerbose(options): boolean {
-  const args = options.args || [];
-  const verboseFlag =
-    args.includes('-Dverbose') || args.includes('-Dverbose=true');
-  if (options.unpruned && !verboseFlag) {
-    args.push('-Dverbose');
-    options.args = args;
-  }
-  return verboseFlag || options.unpruned;
 }

--- a/tests/tap/system/plugin.test.ts
+++ b/tests/tap/system/plugin.test.ts
@@ -408,27 +408,3 @@ test('inspect on verbose-project pom using -Dverbose', async (t) => {
     'returns expected dep-graph',
   );
 });
-
-test('inspect on test-project pom using --unpruned', async (t) => {
-  const result = await plugin.inspect(
-    '.',
-    path.join(testProjectPath, 'pom.xml'),
-    {
-      unpruned: true,
-    },
-  );
-  if (!legacyPlugin.isMultiResult(result)) {
-    return t.fail('expected multi inspect result');
-  }
-  t.equal(result.scannedProjects.length, 1, 'returns 1 scanned project');
-  const expectedJSON = await readFixtureJSON(
-    'test-project',
-    'expected-verbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
-  t.same(
-    result.scannedProjects[0].depGraph?.toJSON(),
-    expectedDepGraph.toJSON(),
-    'returns expected dep-graph',
-  );
-});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
1. Reverts the following changes -> [link to PR](https://github.com/snyk/snyk-mvn-plugin/pull/171)
2. Switched from using lists, to using sets for dependency ancestry