### PR TITLE
feat: support --print-graph as dverbose

### DIFF
--- a/tests/jest/system/dverbose-flag.spec.ts
+++ b/tests/jest/system/dverbose-flag.spec.ts
@@ -28,3 +28,24 @@ test('inspect on dverbose-project pom using -Dverbose', async () => {
   },
   20000,
 );
+
+test('inspect on dverbose-project pom using --print-graph', async () => {
+    let result: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testProjectPath, 'pom.xml'),
+      {
+        'print-graph': true
+      },
+    );
+
+    const expectedJSON = await readFixtureJSON(
+      'dverbose-project',
+      'expected-dverbose-dep-graph.json',
+    );
+    const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
+    result = result.scannedProjects[0].depGraph?.toJSON();
+
+    expect(result).toEqual(expectedDepGraph);
+  },
+  20000,
+);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

We need to disable the pruning to improve the results generated by `snyk sbom`.
The sbom command calls extensions with a `--print-graph` flag when it generates
an SBOM.

This PR makes use of that flag to increase the verbosity, and disabling the pruning.

#### How should this be manually tested?

- Clone snyk/snyk-mvn-plugin and snyk/cli.
- Run `npm link` in the cloned snyk-mvn-plugin directory
- If needed, run `make clean` in the cli directory
- Run `npm link snyk-mvn-plugin` in the cli directory.
- Run `make build` in the cli directory
- Create a folder with a pom.xml file, that usually gets pruned.
- Run `node <path-to-repos>/snyk/cli/dist/cli/index.js test --print-graph`

Compare the result against the same command without `--print-graph`.