### PR TITLE
fix: [OSM-2676] dverbose - queue correct pkg id for visited node

### DIFF
--- a/lib/parse/dep-graph.ts
+++ b/lib/parse/dep-graph.ts
@@ -49,15 +49,18 @@ export function buildDepGraph(
 
     const parentNodeId = parentId === rootId ? builder.rootNodeId : parentId;
     if (verboseEnabled && visited) {
-      // use visited node when omited dependencies found (verbose)
       builder.addPkgNode(visited.pkgInfo, visited.id);
       builder.connectDep(parentNodeId, visited.id);
+      // use visited node when omited dependencies found (verbose)
+
+      // Remember to push updated ancestry here
+      // queue.push(...getItems(visited.id, [...ancestry, visited.id], node));
     } else {
       builder.addPkgNode(parsed.pkgInfo, id);
       builder.connectDep(parentNodeId, id);
       visitedMap[parsed.key] = parsed;
+      // Remember to push updated ancestry here
     }
-    // Remember to push updated ancestry here
     queue.push(...getItems(id, [...ancestry, id], node));
   }
 
@@ -95,7 +98,7 @@ function parseId(id: string): DepInfo {
   const name = `${dep.groupId}:${dep.artifactId}`;
   return {
     id,
-    key: `${name}:${dep.type}${maybeClassifier}`,
+    key: `${name}:${dep.type}${maybeClassifier}:${dep.scope}`,
     pkgInfo: {
       name,
       version: dep.version,

--- a/lib/parse/dep-graph.ts
+++ b/lib/parse/dep-graph.ts
@@ -54,7 +54,7 @@ export function buildDepGraph(
       // use visited node when omited dependencies found (verbose)
 
       // Remember to push updated ancestry here
-      // queue.push(...getItems(visited.id, [...ancestry, visited.id], node));
+      queue.push(...getItems(visited.id, [...ancestry, visited.id], node));
     } else {
       builder.addPkgNode(parsed.pkgInfo, id);
       builder.connectDep(parentNodeId, id);

--- a/lib/parse/digraph.ts
+++ b/lib/parse/digraph.ts
@@ -63,6 +63,8 @@ function isVerbose(value: string): boolean {
     'version managed from',
     'omitted for conflict with',
     'omitted for duplicate',
+    'scope not updated to compile',
+    'scope not updated to test',
   ];
   for (const dverboseReason of dverboseReasons) {
     if (value.includes(dverboseReason)) return true;

--- a/tests/fixtures/parent-node-id/expected-dverbose-dep-graph.json
+++ b/tests/fixtures/parent-node-id/expected-dverbose-dep-graph.json
@@ -1,0 +1,102 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "com.example.scopetest:scope-collision-test@1.0.0",
+      "info": {
+        "name": "com.example.scopetest:scope-collision-test",
+        "version": "1.0.0"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.30",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.30"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-classic@1.2.10",
+      "info": {
+        "name": "ch.qos.logback:logback-classic",
+        "version": "1.2.10"
+      }
+    },
+    {
+      "id": "commons-io:commons-io@2.11.0",
+      "info": {
+        "name": "commons-io:commons-io",
+        "version": "2.11.0"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-core@1.2.10",
+      "info": {
+        "name": "ch.qos.logback:logback-core",
+        "version": "1.2.10"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.32",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.32"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "com.example.scopetest:scope-collision-test@1.0.0",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.30:compile"
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic:jar:1.2.10:runtime"
+          },
+          {
+            "nodeId": "commons-io:commons-io:jar:2.11.0:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.30:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.30",
+        "deps": []
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-classic:jar:1.2.10:runtime",
+        "pkgId": "ch.qos.logback:logback-classic@1.2.10",
+        "deps": [
+          {
+            "nodeId": "ch.qos.logback:logback-core:jar:1.2.10:runtime"
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:runtime"
+          }
+        ]
+      },
+      {
+        "nodeId": "commons-io:commons-io:jar:2.11.0:compile",
+        "pkgId": "commons-io:commons-io@2.11.0",
+        "deps": []
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-core:jar:1.2.10:runtime",
+        "pkgId": "ch.qos.logback:logback-core@1.2.10",
+        "deps": []
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:runtime",
+        "pkgId": "org.slf4j:slf4j-api@1.7.32",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/tests/fixtures/parent-node-id/pom.xml
+++ b/tests/fixtures/parent-node-id/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.scopetest</groupId>
+    <artifactId>scope-collision-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>Scope Key Collision Test</name>
+    <description>
+        Tests scenario where the same dependency is reached via paths
+        with different scopes (compile vs runtime). An older key generation
+        (without scope) might incorrectly prune or misidentify nodes.
+    </description>
+
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Dependency A: Direct compile dependency -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+            <scope>compile</scope> <!-- Explicit Compile Scope -->
+        </dependency>
+
+        <!-- Dependency B: Runtime dependency that transitively requires Dependency A -->
+        <!-- Logback-classic depends on slf4j-api (usually compile scope relative to logback) -->
+        <!-- but logback-classic itself is added here with runtime scope -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <!-- Using a version known to depend on slf4j-api 1.7.x -->
+            <version>1.2.10</version>
+            <scope>runtime</scope> <!-- Explicit Runtime Scope -->
+        </dependency>
+
+        <!-- Add another simple dependency just to make the graph slightly less trivial -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/jest/system/plugin-jar.spec.ts
+++ b/tests/jest/system/plugin-jar.spec.ts
@@ -3,10 +3,15 @@ import * as path from 'path';
 import * as plugin from '../../../lib';
 import { readFixtureJSON } from '../../helpers/read';
 import { mockSnykSearchClient } from '../../helpers/mock-search';
+import * as depGraphLib from '@snyk/dep-graph';
 
 const testsPath = path.join(__dirname, '../..');
 const fixturesPath = path.join(testsPath, 'fixtures');
 const badPath = path.join(fixturesPath, 'bad');
+const testProjectWithWrongParentNodeId = path.join(
+  fixturesPath,
+  'parent-node-id',
+);
 
 test('inspect with spring-core jar file', async () =>
   await assertFixture({
@@ -176,3 +181,22 @@ async function assertFixture({
     (result as legacyPlugin.SinglePackageResult).dependencyGraph!.toJSON(),
   ).toEqual(expected);
 }
+
+test('inspect correctly handles dependencies with different scopes', async () => {
+  let res: Record<string, any> = await plugin.inspect(
+    '.',
+    path.join(testProjectWithWrongParentNodeId, 'pom.xml'),
+    {
+      args: ['-Dverbose'],
+    },
+  );
+
+  const expectedJSON = await readFixtureJSON(
+    'parent-node-id',
+    'expected-dverbose-dep-graph.json',
+  );
+  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
+  const result = res.scannedProjects[0].depGraph?.toJSON();
+
+  expect(result).toEqual(expectedDepGraph);
+}, 20000);


### PR DESCRIPTION
This PR does two things:

1. We started adding the package `scope` to the identity of nodes. This fixes the `parentNodeId does not exist` issue.
2. Using the visited IDs in order to queue the correct package ID for visited nodes. 