### PR TITLE
fix: [OSM-2676] push ids from the correct clause

### DIFF
--- a/lib/parse/dep-graph.ts
+++ b/lib/parse/dep-graph.ts
@@ -60,8 +60,8 @@ export function buildDepGraph(
       builder.connectDep(parentNodeId, id);
       visitedMap[parsed.key] = parsed;
       // Remember to push updated ancestry here
+      queue.push(...getItems(id, [...ancestry, id], node));
     }
-    queue.push(...getItems(id, [...ancestry, id], node));
   }
 
   return builder.build();


### PR DESCRIPTION
Had to move queue.push in the else clause. If we have `visited.id` we use that one, otherwise we use the `id`