### PR TITLE
feat: [OSM-2668] build graph for Dverbose with dfs and keep all Dverbose versions

### DIFF
--- a/tests/fixtures/test-project/expected-verbose-dep-graph.json
+++ b/tests/fixtures/test-project/expected-verbose-dep-graph.json
@@ -19,24 +19,17 @@
       }
     },
     {
-      "id": "org.apache.axis:axis-jaxrpc@1.4",
+      "id": "commons-discovery:commons-discovery@0.2",
       "info": {
-        "name": "org.apache.axis:axis-jaxrpc",
-        "version": "1.4"
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2"
       }
     },
     {
-      "id": "org.apache.axis:axis-saaj@1.4",
+      "id": "commons-logging:commons-logging@1.0.3",
       "info": {
-        "name": "org.apache.axis:axis-saaj",
-        "version": "1.4"
-      }
-    },
-    {
-      "id": "axis:axis-wsdl4j@1.5.1",
-      "info": {
-        "name": "axis:axis-wsdl4j",
-        "version": "1.5.1"
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.3"
       }
     },
     {
@@ -47,10 +40,24 @@
       }
     },
     {
-      "id": "commons-discovery:commons-discovery@0.2",
+      "id": "axis:axis-wsdl4j@1.5.1",
       "info": {
-        "name": "commons-discovery:commons-discovery",
-        "version": "0.2"
+        "name": "axis:axis-wsdl4j",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-saaj@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-saaj",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-jaxrpc@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-jaxrpc",
+        "version": "1.4"
       }
     }
   ],
@@ -71,35 +78,34 @@
         "pkgId": "axis:axis@1.4",
         "deps": [
           {
-            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
-          },
-          {
-            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
-          },
-          {
-            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
           },
           {
             "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
           },
           {
-            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
+            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
           }
         ]
       },
       {
-        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
-        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
-        "deps": []
+        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
+        "pkgId": "commons-discovery:commons-discovery@0.2",
+        "deps": [
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime"
+          }
+        ]
       },
       {
-        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
-        "pkgId": "org.apache.axis:axis-saaj@1.4",
-        "deps": []
-      },
-      {
-        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
-        "pkgId": "axis:axis-wsdl4j@1.5.1",
+        "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.3",
         "deps": []
       },
       {
@@ -108,13 +114,19 @@
         "deps": []
       },
       {
-        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
-        "pkgId": "commons-discovery:commons-discovery@0.2",
-        "deps": [
-          {
-            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
-          }
-        ]
+        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
+        "pkgId": "axis:axis-wsdl4j@1.5.1",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-saaj@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
+        "deps": []
       }
     ]
   }

--- a/tests/fixtures/verbose-project/expected-verbose-dep-graph.json
+++ b/tests/fixtures/verbose-project/expected-verbose-dep-graph.json
@@ -12,107 +12,9 @@
       }
     },
     {
-      "id": "axis:axis@1.4",
-      "info": {
-        "name": "axis:axis",
-        "version": "1.4"
-      }
-    },
-    {
-      "id": "org.springframework.boot:spring-boot-starter@2.7.15",
-      "info": {
-        "name": "org.springframework.boot:spring-boot-starter",
-        "version": "2.7.15"
-      }
-    },
-    {
       "id": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.2",
       "info": {
         "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
-        "version": "2.14.2"
-      }
-    },
-    {
-      "id": "org.apache.axis:axis-jaxrpc@1.4",
-      "info": {
-        "name": "org.apache.axis:axis-jaxrpc",
-        "version": "1.4"
-      }
-    },
-    {
-      "id": "org.apache.axis:axis-saaj@1.4",
-      "info": {
-        "name": "org.apache.axis:axis-saaj",
-        "version": "1.4"
-      }
-    },
-    {
-      "id": "axis:axis-wsdl4j@1.5.1",
-      "info": {
-        "name": "axis:axis-wsdl4j",
-        "version": "1.5.1"
-      }
-    },
-    {
-      "id": "commons-logging:commons-logging@1.0.4",
-      "info": {
-        "name": "commons-logging:commons-logging",
-        "version": "1.0.4"
-      }
-    },
-    {
-      "id": "commons-discovery:commons-discovery@0.2",
-      "info": {
-        "name": "commons-discovery:commons-discovery",
-        "version": "0.2"
-      }
-    },
-    {
-      "id": "org.springframework.boot:spring-boot@2.7.15",
-      "info": {
-        "name": "org.springframework.boot:spring-boot",
-        "version": "2.7.15"
-      }
-    },
-    {
-      "id": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
-      "info": {
-        "name": "org.springframework.boot:spring-boot-autoconfigure",
-        "version": "2.7.15"
-      }
-    },
-    {
-      "id": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
-      "info": {
-        "name": "org.springframework.boot:spring-boot-starter-logging",
-        "version": "2.7.15"
-      }
-    },
-    {
-      "id": "jakarta.annotation:jakarta.annotation-api@1.3.5",
-      "info": {
-        "name": "jakarta.annotation:jakarta.annotation-api",
-        "version": "1.3.5"
-      }
-    },
-    {
-      "id": "org.springframework:spring-core@5.3.29",
-      "info": {
-        "name": "org.springframework:spring-core",
-        "version": "5.3.29"
-      }
-    },
-    {
-      "id": "org.yaml:snakeyaml@1.30",
-      "info": {
-        "name": "org.yaml:snakeyaml",
-        "version": "1.30"
-      }
-    },
-    {
-      "id": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
-      "info": {
-        "name": "com.fasterxml.jackson.core:jackson-databind",
         "version": "2.14.2"
       }
     },
@@ -124,38 +26,17 @@
       }
     },
     {
-      "id": "org.springframework:spring-context@5.3.29",
+      "id": "org.yaml:snakeyaml@1.33",
       "info": {
-        "name": "org.springframework:spring-context",
-        "version": "5.3.29"
+        "name": "org.yaml:snakeyaml",
+        "version": "1.33"
       }
     },
     {
-      "id": "ch.qos.logback:logback-classic@1.2.12",
+      "id": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
       "info": {
-        "name": "ch.qos.logback:logback-classic",
-        "version": "1.2.12"
-      }
-    },
-    {
-      "id": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
-      "info": {
-        "name": "org.apache.logging.log4j:log4j-to-slf4j",
-        "version": "2.17.2"
-      }
-    },
-    {
-      "id": "org.slf4j:jul-to-slf4j@1.7.36",
-      "info": {
-        "name": "org.slf4j:jul-to-slf4j",
-        "version": "1.7.36"
-      }
-    },
-    {
-      "id": "org.springframework:spring-jcl@5.3.29",
-      "info": {
-        "name": "org.springframework:spring-jcl",
-        "version": "5.3.29"
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "2.14.2"
       }
     },
     {
@@ -166,30 +47,86 @@
       }
     },
     {
-      "id": "org.springframework:spring-aop@5.3.29",
+      "id": "org.springframework.boot:spring-boot-starter@2.7.15",
       "info": {
-        "name": "org.springframework:spring-aop",
+        "name": "org.springframework.boot:spring-boot-starter",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.yaml:snakeyaml@1.30",
+      "info": {
+        "name": "org.yaml:snakeyaml",
+        "version": "1.30"
+      }
+    },
+    {
+      "id": "org.springframework:spring-core@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-core",
         "version": "5.3.29"
       }
     },
     {
-      "id": "org.springframework:spring-beans@5.3.29",
+      "id": "org.springframework:spring-jcl@5.3.29",
       "info": {
-        "name": "org.springframework:spring-beans",
+        "name": "org.springframework:spring-jcl",
         "version": "5.3.29"
       }
     },
     {
-      "id": "org.springframework:spring-expression@5.3.29",
+      "id": "jakarta.annotation:jakarta.annotation-api@1.3.5",
       "info": {
-        "name": "org.springframework:spring-expression",
-        "version": "5.3.29"
+        "name": "jakarta.annotation:jakarta.annotation-api",
+        "version": "1.3.5"
       }
     },
     {
-      "id": "ch.qos.logback:logback-core@1.2.12",
+      "id": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
       "info": {
-        "name": "ch.qos.logback:logback-core",
+        "name": "org.springframework.boot:spring-boot-starter-logging",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.slf4j:jul-to-slf4j@1.7.36",
+      "info": {
+        "name": "org.slf4j:jul-to-slf4j",
+        "version": "1.7.36"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.36",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.36"
+      }
+    },
+    {
+      "id": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
+      "info": {
+        "name": "org.apache.logging.log4j:log4j-to-slf4j",
+        "version": "2.17.2"
+      }
+    },
+    {
+      "id": "org.apache.logging.log4j:log4j-api@2.17.2",
+      "info": {
+        "name": "org.apache.logging.log4j:log4j-api",
+        "version": "2.17.2"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.35",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.35"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-classic@1.2.12",
+      "info": {
+        "name": "ch.qos.logback:logback-classic",
         "version": "1.2.12"
       }
     },
@@ -201,10 +138,101 @@
       }
     },
     {
-      "id": "org.apache.logging.log4j:log4j-api@2.17.2",
+      "id": "ch.qos.logback:logback-core@1.2.12",
       "info": {
-        "name": "org.apache.logging.log4j:log4j-api",
-        "version": "2.17.2"
+        "name": "ch.qos.logback:logback-core",
+        "version": "1.2.12"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-autoconfigure",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.springframework:spring-context@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-context",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-expression@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-expression",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-beans@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-beans",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-aop@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-aop",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "axis:axis@1.4",
+      "info": {
+        "name": "axis:axis",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "commons-discovery:commons-discovery@0.2",
+      "info": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2"
+      }
+    },
+    {
+      "id": "commons-logging:commons-logging@1.0.3",
+      "info": {
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "commons-logging:commons-logging@1.0.4",
+      "info": {
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "axis:axis-wsdl4j@1.5.1",
+      "info": {
+        "name": "axis:axis-wsdl4j",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-saaj@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-saaj",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-jaxrpc@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-jaxrpc",
+        "version": "1.4"
       }
     }
   ],
@@ -216,58 +244,13 @@
         "pkgId": "io.snyk.example:verbose-project@1.0-SNAPSHOT",
         "deps": [
           {
-            "nodeId": "axis:axis:jar:1.4:compile"
+            "nodeId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:compile"
           },
           {
             "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile"
           },
           {
-            "nodeId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "axis:axis:jar:1.4:compile",
-        "pkgId": "axis:axis@1.4",
-        "deps": [
-          {
-            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
-          },
-          {
-            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
-          },
-          {
-            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
-          },
-          {
-            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
-          },
-          {
-            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
-          }
-        ]
-      },
-      {
-        "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile",
-        "pkgId": "org.springframework.boot:spring-boot-starter@2.7.15",
-        "deps": [
-          {
-            "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
-          },
-          {
-            "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile"
-          },
-          {
-            "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile"
-          },
-          {
-            "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile"
-          },
-          {
-            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
-          },
-          {
-            "nodeId": "org.yaml:snakeyaml:jar:1.30:compile"
+            "nodeId": "axis:axis:jar:1.4:compile"
           }
         ]
       },
@@ -276,84 +259,70 @@
         "pkgId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.2",
         "deps": [
           {
-            "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile"
+            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
           },
+          {
+            "nodeId": "org.yaml:snakeyaml:jar:1.33:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-core@2.14.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.yaml:snakeyaml:jar:1.33:compile",
+        "pkgId": "org.yaml:snakeyaml@1.33",
+        "deps": []
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
+        "deps": [
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-annotations@2.14.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-starter@2.7.15",
+        "deps": [
           {
             "nodeId": "org.yaml:snakeyaml:jar:1.30:compile"
           },
           {
-            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
-        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
-        "deps": []
-      },
-      {
-        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
-        "pkgId": "org.apache.axis:axis-saaj@1.4",
-        "deps": []
-      },
-      {
-        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
-        "pkgId": "axis:axis-wsdl4j@1.5.1",
-        "deps": []
-      },
-      {
-        "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime",
-        "pkgId": "commons-logging:commons-logging@1.0.4",
-        "deps": []
-      },
-      {
-        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
-        "pkgId": "commons-discovery:commons-discovery@0.2",
-        "deps": [
-          {
-            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
-          }
-        ]
-      },
-      {
-        "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile",
-        "pkgId": "org.springframework.boot:spring-boot@2.7.15",
-        "deps": [
-          {
             "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
           },
           {
-            "nodeId": "org.springframework:spring-context:jar:5.3.29:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile",
-        "pkgId": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
-        "deps": [
+            "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile"
+          },
           {
             "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
           }
         ]
       },
       {
-        "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile",
-        "pkgId": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
-        "deps": [
-          {
-            "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile"
-          },
-          {
-            "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile"
-          },
-          {
-            "nodeId": "org.slf4j:jul-to-slf4j:jar:1.7.36:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile",
-        "pkgId": "jakarta.annotation:jakarta.annotation-api@1.3.5",
+        "nodeId": "org.yaml:snakeyaml:jar:1.30:compile",
+        "pkgId": "org.yaml:snakeyaml@1.30",
         "deps": []
       },
       {
@@ -366,66 +335,27 @@
         ]
       },
       {
-        "nodeId": "org.yaml:snakeyaml:jar:1.30:compile",
-        "pkgId": "org.yaml:snakeyaml@1.30",
+        "nodeId": "org.springframework:spring-jcl:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-jcl@5.3.29",
         "deps": []
       },
       {
-        "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile",
-        "pkgId": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
-        "deps": [
-          {
-            "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile"
-          },
-          {
-            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile",
-        "pkgId": "com.fasterxml.jackson.core:jackson-core@2.14.2",
+        "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile",
+        "pkgId": "jakarta.annotation:jakarta.annotation-api@1.3.5",
         "deps": []
       },
       {
-        "nodeId": "org.springframework:spring-context:jar:5.3.29:compile",
-        "pkgId": "org.springframework:spring-context@5.3.29",
+        "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
         "deps": [
           {
-            "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile"
+            "nodeId": "org.slf4j:jul-to-slf4j:jar:1.7.36:compile"
           },
           {
-            "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
+            "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile"
           },
           {
-            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
-          },
-          {
-            "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile",
-        "pkgId": "ch.qos.logback:logback-classic@1.2.12",
-        "deps": [
-          {
-            "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile"
-          },
-          {
-            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
-          }
-        ]
-      },
-      {
-        "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile",
-        "pkgId": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
-        "deps": [
-          {
-            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
-          },
-          {
-            "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+            "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile"
           }
         ]
       },
@@ -434,27 +364,102 @@
         "pkgId": "org.slf4j:jul-to-slf4j@1.7.36",
         "deps": [
           {
-            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.36:compile"
           }
         ]
       },
       {
-        "nodeId": "org.springframework:spring-jcl:jar:5.3.29:compile",
-        "pkgId": "org.springframework:spring-jcl@5.3.29",
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.36:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.36",
         "deps": []
       },
       {
-        "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile",
-        "pkgId": "com.fasterxml.jackson.core:jackson-annotations@2.14.2",
-        "deps": []
-      },
-      {
-        "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile",
-        "pkgId": "org.springframework:spring-aop@5.3.29",
+        "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile",
+        "pkgId": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
         "deps": [
+          {
+            "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.35:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile",
+        "pkgId": "org.apache.logging.log4j:log4j-api@2.17.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.35:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.35",
+        "deps": []
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile",
+        "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.32",
+        "deps": []
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile",
+        "pkgId": "ch.qos.logback:logback-core@1.2.12",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-context:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-context:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-context@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
           {
             "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
           },
+          {
+            "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-expression@5.3.29",
+        "deps": [
           {
             "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
           }
@@ -470,27 +475,70 @@
         ]
       },
       {
-        "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile",
-        "pkgId": "org.springframework:spring-expression@5.3.29",
+        "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-aop@5.3.29",
         "deps": [
           {
             "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
           }
         ]
       },
       {
-        "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile",
-        "pkgId": "ch.qos.logback:logback-core@1.2.12",
+        "nodeId": "axis:axis:jar:1.4:compile",
+        "pkgId": "axis:axis@1.4",
+        "deps": [
+          {
+            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
+          },
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+          },
+          {
+            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
+        "pkgId": "commons-discovery:commons-discovery@0.2",
+        "deps": [
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime"
+          }
+        ]
+      },
+      {
+        "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.3",
         "deps": []
       },
       {
-        "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile",
-        "pkgId": "org.slf4j:slf4j-api@1.7.32",
+        "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.4",
         "deps": []
       },
       {
-        "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile",
-        "pkgId": "org.apache.logging.log4j:log4j-api@2.17.2",
+        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
+        "pkgId": "axis:axis-wsdl4j@1.5.1",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-saaj@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
         "deps": []
       }
     ]

--- a/tests/helpers/sort.ts
+++ b/tests/helpers/sort.ts
@@ -1,5 +1,38 @@
-import type { PkgInfo } from '@snyk/dep-graph';
+import type { DepGraphData, PkgInfo } from '@snyk/dep-graph';
+import { GraphNode } from '@snyk/dep-graph/dist/core/types';
+
+type PkgData = {
+  id: string;
+  info: PkgInfo;
+};
+
+type NodeDep = {
+  nodeId: string;
+};
 
 export function byPkgName(a: PkgInfo, b: PkgInfo): number {
   return a.name.length - b.name.length;
+}
+
+export function sortDependencyGraphDeps(graph: DepGraphData): DepGraphData {
+  if (graph && graph.graph && graph.graph.nodes) {
+    // Sort the top-level pkgs array by id
+    if (Array.isArray(graph.pkgs)) {
+      graph.pkgs.sort((a: PkgData, b: PkgData) => a.id.localeCompare(b.id));
+    }
+    // Sort the top-level nodes array by nodeId
+    graph.graph.nodes.sort((a: GraphNode, b: GraphNode) =>
+      a.nodeId.localeCompare(b.nodeId),
+    );
+
+    // Sort the deps array within each node
+    graph.graph.nodes.forEach((node: any) => {
+      if (node.deps && Array.isArray(node.deps)) {
+        node.deps.sort((a: NodeDep, b: NodeDep) =>
+          a.nodeId.localeCompare(b.nodeId),
+        );
+      }
+    });
+  }
+  return graph;
 }

--- a/tests/jest/system/dverbose-flag.spec.ts
+++ b/tests/jest/system/dverbose-flag.spec.ts
@@ -1,9 +1,10 @@
 import * as plugin from '../../../lib';
 import * as path from 'path';
 import { readFixtureJSON } from '../../helpers/read';
-import * as depGraphLib from '@snyk/dep-graph';
 import * as subProcess from '../../../lib/sub-process';
-import { writeFileSync } from 'fs';
+import { sortDependencyGraphDeps } from '../../helpers/sort';
+import { DepGraphData } from '@snyk/dep-graph';
+import { legacyPlugin } from '@snyk/cli-interface';
 
 const testsPath = path.join(__dirname, '../..');
 const fixturesPath = path.join(testsPath, 'fixtures');
@@ -13,156 +14,241 @@ const testManagedProjectPath = path.join(
   'dverbose-dependency-management',
 );
 const complexProjectPath = path.join(fixturesPath, 'complex-aggregate-project');
+const TESTS_TIMEOUT = 50000;
 
-test('inspect on dverbose-project pom using -Dverbose', async () => {
-  let res: Record<string, any> = await plugin.inspect(
-    '.',
-    path.join(testProjectPath, 'pom.xml'),
-    {
+test(
+  'inspect on dverbose-project pom using -Dverbose',
+  async () => {
+    const res: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testProjectPath, 'pom.xml'),
+      {
+        args: ['-Dverbose'],
+      },
+    );
+
+    const expectedJSON: DepGraphData = await readFixtureJSON(
+      'dverbose-project',
+      'expected-dverbose-dep-graph.json',
+    );
+    const result = res.scannedProjects[0].depGraph.toJSON();
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(result);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    expect(
+      res.plugin.meta.versionBuildInfo.metaBuildVersion.mavenPluginVersion,
+    ).toEqual('3.6.1');
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on dverbose-dependency-management pom using -Dverbose',
+  async () => {
+    const res: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testManagedProjectPath, 'pom.xml'),
+      {
+        args: ['-Dverbose'],
+      },
+    );
+    const result = res.scannedProjects[0].depGraph.toJSON();
+
+    const expectedJSON = await readFixtureJSON(
+      'dverbose-dependency-management',
+      'expected-dverbose-dep-graph.json',
+    );
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(result);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on dverbose-dependency-management pom using -Dverbose and --dev deps',
+  async () => {
+    const res: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testManagedProjectPath, 'pom.xml'),
+      {
+        dev: true,
+        args: ['-Dverbose'],
+      },
+    );
+    const result = res.scannedProjects[0].depGraph.toJSON();
+
+    // if running windows with an older version of maven 3.3.9.2 - one of the deps will be omitted
+    const mavenVersion = await subProcess.execute(`mvn --version`, [], {});
+    let expectedJSON = await readFixtureJSON(
+      'dverbose-dependency-management',
+      mavenVersion.includes('3.3.9') && mavenVersion.includes('C:')
+        ? 'expected-dverbose-dep-graph-dev-old-maven.json'
+        : 'expected-dverbose-dep-graph-dev.json',
+    );
+
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(result);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on complext-aggregate-project using -Dverbose and --mavenAggregateProject deps',
+  async () => {
+    let result: Record<string, any> = await plugin.inspect(
+      complexProjectPath,
+      'pom.xml',
+      {
+        args: ['-Dverbose'],
+        mavenAggregateProject: true,
+      },
+    );
+
+    let expectedJSON = await readFixtureJSON(
+      'complex-aggregate-project',
+      'verbose-scan-result.json',
+    );
+
+    expect(result.scannedProjects.length).toEqual(
+      expectedJSON.scannedProjects.length,
+    );
+    for (let i = 0; i < result.scannedProjects.length; i++) {
+      const depGraph = result.scannedProjects[i].depGraph.toJSON();
+      const expectedGraphSorted = sortDependencyGraphDeps(
+        expectedJSON.scannedProjects[i].depGraph,
+      );
+      const actualGraphSorted = sortDependencyGraphDeps(depGraph);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    }
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on dverbose-project pom using --print-graph',
+  async () => {
+    const res: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testProjectPath, 'pom.xml'),
+      {
+        'print-graph': true,
+      },
+    );
+
+    const expectedJSON = await readFixtureJSON(
+      'dverbose-project',
+      'expected-dverbose-dep-graph.json',
+    );
+    const result = res.scannedProjects[0].depGraph.toJSON();
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(result);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on dverbose-clashing-scopes pom using -Dverbose',
+  async () => {
+    const fixture = 'dverbose-clashing-scopes';
+    const testPath = path.join(fixturesPath, fixture);
+    let res: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testPath, 'pom.xml'),
+      {
+        args: ['-Dverbose'],
+      },
+    );
+
+    const expectedJSON = await readFixtureJSON(
+      fixture,
+      'expected-dverbose-dep-graph.json',
+    );
+    const result = res.scannedProjects[0].depGraph.toJSON();
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(result);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on dverbose-diff-scopes-versions pom using -Dverbose',
+  async () => {
+    const fixture = 'dverbose-diff-scopes-versions';
+    const testPath = path.join(fixturesPath, fixture);
+    let res: Record<string, any> = await plugin.inspect(
+      '.',
+      path.join(testPath, 'pom.xml'),
+      {
+        args: ['-Dverbose'],
+      },
+    );
+
+    const expectedJSON = await readFixtureJSON(
+      fixture,
+      'expected-dverbose-dep-graph.json',
+    );
+    const result = res.scannedProjects[0].depGraph.toJSON();
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(result);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);
+
+test(
+  'inspect on test-project pom using -Dverbose',
+  async () => {
+    const fixture = 'test-project';
+    const testPath = path.join(fixturesPath, fixture);
+    const result = await plugin.inspect('.', path.join(testPath, 'pom.xml'), {
       args: ['-Dverbose'],
-    },
-  );
+    });
+    if (!legacyPlugin.isMultiResult(result)) {
+      fail('expected multi inspect result');
+    }
+    expect(result.scannedProjects.length).toEqual(1);
+    const expectedJSON = await readFixtureJSON(
+      'test-project',
+      'expected-verbose-dep-graph.json',
+    );
+    const res = result.scannedProjects[0].depGraph?.toJSON();
+    if (!res) {
+      fail('expected dependency graph result');
+    }
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(res);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);
 
-  const expectedJSON = await readFixtureJSON(
-    'dverbose-project',
-    'expected-dverbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
-  const result = res.scannedProjects[0].depGraph?.toJSON();
-
-  expect(result).toEqual(expectedDepGraph);
-  expect(
-    res.plugin.meta.versionBuildInfo.metaBuildVersion.mavenPluginVersion,
-  ).toEqual('3.6.1');
-}, 20000);
-
-test('inspect on dverbose-dependency-management pom using -Dverbose', async () => {
-  let result: Record<string, any> = await plugin.inspect(
-    '.',
-    path.join(testManagedProjectPath, 'pom.xml'),
-    {
+test(
+  'inspect on verbose-project pom using -Dverbose',
+  async () => {
+    const fixture = 'verbose-project';
+    const testPath = path.join(fixturesPath, fixture);
+    const result = await plugin.inspect('.', testPath, {
       args: ['-Dverbose'],
-    },
-  );
-
-  const expectedJSON = await readFixtureJSON(
-    'dverbose-dependency-management',
-    'expected-dverbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
-  result = result.scannedProjects[0].depGraph?.toJSON();
-
-  expect(result).toEqual(expectedDepGraph);
-}, 20000);
-
-test('inspect on dverbose-dependency-management pom using -Dverbose and --dev deps', async () => {
-  let result: Record<string, any> = await plugin.inspect(
-    '.',
-    path.join(testManagedProjectPath, 'pom.xml'),
-    {
-      dev: true,
-      args: ['-Dverbose'],
-    },
-  );
-
-  // if running windows with an older version of maven 3.3.9.2 - one of the deps will be omitted
-  const mavenVersion = await subProcess.execute(`mvn --version`, [], {});
-  let expectedJSON = await readFixtureJSON(
-    'dverbose-dependency-management',
-    mavenVersion.includes('3.3.9') && mavenVersion.includes('C:')
-      ? 'expected-dverbose-dep-graph-dev-old-maven.json'
-      : 'expected-dverbose-dep-graph-dev.json',
-  );
-
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
-  result = result.scannedProjects[0].depGraph?.toJSON();
-
-  expect(result).toEqual(expectedDepGraph);
-}, 20000);
-
-test('inspect on complext-aggregate-project using -Dverbose and --mavenAggregateProject deps', async () => {
-  let result: Record<string, any> = await plugin.inspect(
-    complexProjectPath,
-    'pom.xml',
-    {
-      args: ['-Dverbose'],
-      mavenAggregateProject: true,
-    },
-  );
-
-  let expectedJSON = await readFixtureJSON(
-    'complex-aggregate-project',
-    'verbose-scan-result.json',
-  );
-
-  expect(result.scannedProjects.length).toEqual(
-    expectedJSON.scannedProjects.length,
-  );
-  for (let i = 0; i < result.scannedProjects.length; i++) {
-    const expectedDepGraph = depGraphLib
-      .createFromJSON(expectedJSON.scannedProjects[i].depGraph)
-      .toJSON();
-    const depGraph = result.scannedProjects[i].depGraph?.toJSON();
-
-    expect(depGraph).toEqual(expectedDepGraph);
-  }
-}, 20000);
-
-test('inspect on dverbose-project pom using --print-graph', async () => {
-  let result: Record<string, any> = await plugin.inspect(
-    '.',
-    path.join(testProjectPath, 'pom.xml'),
-    {
-      'print-graph': true,
-    },
-  );
-
-  const expectedJSON = await readFixtureJSON(
-    'dverbose-project',
-    'expected-dverbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
-  result = result.scannedProjects[0].depGraph?.toJSON();
-
-  expect(result).toEqual(expectedDepGraph);
-}, 20000);
-
-test('inspect on dverbose-clashing-scopes pom using -Dverbose', async () => {
-  const fixture = 'dverbose-clashing-scopes';
-  const testPath = path.join(fixturesPath, fixture);
-  let res: Record<string, any> = await plugin.inspect(
-    '.',
-    path.join(testPath, 'pom.xml'),
-    {
-      args: ['-Dverbose'],
-    },
-  );
-
-  const expectedJSON = await readFixtureJSON(
-    fixture,
-    'expected-dverbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
-  const result = res.scannedProjects[0].depGraph?.toJSON();
-  expect(result).toEqual(expectedDepGraph);
-}, 20000);
-
-test('inspect on dverbose-diff-scopes-versions pom using -Dverbose', async () => {
-  const fixture = 'dverbose-diff-scopes-versions';
-  const testPath = path.join(fixturesPath, fixture);
-  let res: Record<string, any> = await plugin.inspect(
-    '.',
-    path.join(testPath, 'pom.xml'),
-    {
-      args: ['-Dverbose'],
-    },
-  );
-
-  const expectedJSON = await readFixtureJSON(
-    fixture,
-    'expected-dverbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON).toJSON();
-  const result = res.scannedProjects[0].depGraph?.toJSON();
-  expect(result).toEqual(expectedDepGraph);
-}, 20000);
+    });
+    if (!legacyPlugin.isMultiResult(result)) {
+      return fail('expected multi inspect result');
+    }
+    expect(result.scannedProjects.length).toEqual(1);
+    const expectedJSON = await readFixtureJSON(
+      'verbose-project',
+      'expected-verbose-dep-graph.json',
+    );
+    const res = result.scannedProjects[0].depGraph?.toJSON();
+    if (!res) {
+      fail('expected dependency graph result');
+    }
+    const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+    const actualGraphSorted = sortDependencyGraphDeps(res);
+    expect(expectedGraphSorted).toEqual(actualGraphSorted);
+  },
+  TESTS_TIMEOUT,
+);

--- a/tests/jest/system/reactor.spec.ts
+++ b/tests/jest/system/reactor.spec.ts
@@ -2,7 +2,7 @@ import type { PkgInfo } from '@snyk/dep-graph';
 import * as path from 'path';
 import { legacyPlugin } from '@snyk/cli-interface';
 import * as plugin from '../../../lib';
-import { byPkgName } from '../../helpers/sort';
+import { byPkgName, sortDependencyGraphDeps } from '../../helpers/sort';
 import { readFixtureJSON } from '../../helpers/read';
 import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
 
@@ -166,13 +166,25 @@ test('inspect on complex aggregate project using maven reactor and verbose enabl
     'verbose-scan-result.json',
   );
   expect(result.scannedProjects.length).toEqual(3);
-  expect(result.scannedProjects[0].depGraph?.toJSON()).toEqual(
-    expectedJSON.scannedProjects[0].depGraph,
-  );
-  expect(result.scannedProjects[1].depGraph?.toJSON()).toEqual(
-    expectedJSON.scannedProjects[1].depGraph,
-  );
-  expect(result.scannedProjects[2].depGraph?.toJSON()).toEqual(
-    expectedJSON.scannedProjects[2].depGraph,
-  );
-}, 20000);
+
+  if (!result.scannedProjects[0].depGraph) {
+    fail('expected dependency graph result');
+  }
+  expect(
+    sortDependencyGraphDeps(result.scannedProjects[0].depGraph.toJSON()),
+  ).toEqual(sortDependencyGraphDeps(expectedJSON.scannedProjects[0].depGraph));
+
+  if (!result.scannedProjects[1].depGraph) {
+    fail('expected dependency graph result');
+  }
+  expect(
+    sortDependencyGraphDeps(result.scannedProjects[1].depGraph.toJSON()),
+  ).toEqual(sortDependencyGraphDeps(expectedJSON.scannedProjects[1].depGraph));
+
+  if (!result.scannedProjects[2].depGraph) {
+    fail('expected dependency graph result');
+  }
+  expect(
+    sortDependencyGraphDeps(result.scannedProjects[2].depGraph.toJSON()),
+  ).toEqual(sortDependencyGraphDeps(expectedJSON.scannedProjects[2].depGraph));
+}, 60000);

--- a/tests/tap/system/plugin.test.ts
+++ b/tests/tap/system/plugin.test.ts
@@ -9,7 +9,6 @@ import * as depGraphLib from '@snyk/dep-graph';
 const testsPath = path.join(__dirname, '../..');
 const fixturesPath = path.join(testsPath, 'fixtures');
 const testProjectPath = path.join(fixturesPath, 'test-project');
-const verboseProjectPath = path.join(fixturesPath, 'verbose-project');
 
 test('inspect on test-project pom', async (t) => {
   const result = await plugin.inspect(
@@ -358,53 +357,5 @@ test('inspect on aggregate project root pom', async (t) => {
     result.scannedProjects[0].depGraph?.getDepPkgs().length,
     0,
     'root has 0 dependencies',
-  );
-});
-
-test('inspect on test-project pom using -Dverbose', async (t) => {
-  const result = await plugin.inspect(
-    '.',
-    path.join(testProjectPath, 'pom.xml'),
-    {
-      args: ['-Dverbose'],
-    },
-  );
-  if (!legacyPlugin.isMultiResult(result)) {
-    return t.fail('expected multi inspect result');
-  }
-  t.equal(result.scannedProjects.length, 1, 'returns 1 scanned project');
-  const expectedJSON = await readFixtureJSON(
-    'test-project',
-    'expected-verbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
-  t.same(
-    result.scannedProjects[0].depGraph?.toJSON(),
-    expectedDepGraph.toJSON(),
-    'returns expected dep-graph',
-  );
-});
-
-test('inspect on verbose-project pom using -Dverbose', async (t) => {
-  const result = await plugin.inspect(
-    '.',
-    path.join(verboseProjectPath, 'pom.xml'),
-    {
-      args: ['-Dverbose'],
-    },
-  );
-  if (!legacyPlugin.isMultiResult(result)) {
-    return t.fail('expected multi inspect result');
-  }
-  t.equal(result.scannedProjects.length, 1, 'returns 1 scanned project');
-  const expectedJSON = await readFixtureJSON(
-    'verbose-project',
-    'expected-verbose-dep-graph.json',
-  );
-  const expectedDepGraph = depGraphLib.createFromJSON(expectedJSON);
-  t.same(
-    result.scannedProjects[0].depGraph?.toJSON(),
-    expectedDepGraph.toJSON(),
-    'returns expected dep-graph',
   );
 });


### PR DESCRIPTION
#### What does this PR do?

These changes only apply for Dverbose.
1. Uses DFS for graph creation - for cycles and dense graphs.
2. Uses the package version in the key for the visited/ancestry.

Introduced a graph sort function for testing. The order of the nodes in the depGraph is changed due to the dfs change. Sorting, we can ensure the existence of the same nodes and the relationship between them. Most of the testcases keep the previous dependencies and relations.

The 2 test cases affected by the `package version in the dep key` change are the ones moved from tap tests to jest tests. Their expected graph is also updated. There are a few packages that get resolved with multiple versions by maven -Dverbose (showed as omitted). We'll keep all the versions that Dverbose outputs for now.

If it is decided to only keep the scope/versions that maven resolves dependencies to, we need to introduce more logic around the maven -Dverbose reasons. This is because we no longer process packages with the `shortest path resolution` first, as we switched to DFS.

