### PR TITLE
fix: [CLI-194] removing the shell usage of subprocesses and fixing wrong API usage

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -183,8 +183,8 @@ export async function inspect(
       cwd: mvnWorkingDirectory,
     });
     const versionResult = await subProcess.execute(
-      `${mavenCommand} --version`,
-      [],
+      mavenCommand,
+      ['--version'],
       {
         cwd: mvnWorkingDirectory,
       },

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,18 +1,18 @@
 import * as childProcess from 'child_process';
 import { debug } from './index';
-import { quoteAll } from 'shescape/stateless';
+import { escapeAll } from 'shescape/stateless';
 
 export function execute(command, args, options): Promise<string> {
   const spawnOptions: {
     shell: boolean;
     cwd?: string;
     env: Record<string, string | undefined>;
-  } = { shell: true, env: { ...process.env } };
+  } = { shell: false, env: { ...process.env } };
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
   if (args) {
-    args = quoteAll(args, { flagProtection: false });
+    args = escapeAll(args, { ...spawnOptions, flagProtection: false });
   }
 
   // Before spawning an external process, we look if we need to restore the system proxy configuration,

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -13,8 +13,7 @@ export function execute(command, args, options): Promise<string> {
   // Using shell: true has been deprecated in Node v24 and beyond. See:
   // https://nodejs.org/docs/latest-v24.x/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option-true
   // However, this breaks on Windows, which means we must keep supporting it here.
-  // Note that "win32" is the common name for the Windows API, not 32-bit architecture.
-  if (os.platform() === 'win32') {
+  if (['win32', 'cygwin'].includes(os.platform())) {
     spawnOptions.shell = true;
   }
 

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,6 +1,7 @@
 import * as childProcess from 'child_process';
 import { debug } from './index';
 import { escapeAll } from 'shescape/stateless';
+import * as os from 'node:os';
 
 export function execute(command, args, options): Promise<string> {
   const spawnOptions: {
@@ -8,6 +9,15 @@ export function execute(command, args, options): Promise<string> {
     cwd?: string;
     env: Record<string, string | undefined>;
   } = { shell: false, env: { ...process.env } };
+
+  // Using shell: true has been deprecated in Node v24 and beyond. See:
+  // https://nodejs.org/docs/latest-v24.x/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option-true
+  // However, this breaks on Windows, which means we must keep supporting it here.
+  // Note that "win32" is the common name for the Windows API, not 32-bit architecture.
+  if (os.platform() === 'win32') {
+    spawnOptions.shell = true;
+  }
+
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "debug": "^4.3.4",
     "glob": "^7.1.6",
     "packageurl-js": "^1.0.0",
-    "shescape": "2.1.4",
+    "shescape": "^2.1.4",
     "tslib": "^2.4.0"
   }
 }

--- a/tests/jest/system/dverbose-flag.spec.ts
+++ b/tests/jest/system/dverbose-flag.spec.ts
@@ -79,7 +79,7 @@ test(
     const result = res.scannedProjects[0].depGraph.toJSON();
 
     // if running windows with an older version of maven 3.3.9.2 - one of the deps will be omitted
-    const mavenVersion = await subProcess.execute(`mvn --version`, [], {});
+    const mavenVersion = await subProcess.execute('mvn', ['--version'], {});
     let expectedJSON = await readFixtureJSON(
       'dverbose-dependency-management',
       mavenVersion.includes('3.3.9') && mavenVersion.includes('C:')


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The `subProcess` API is used wrongly in this codebase and we detected issues when running on the executors on the CLI [pipeline](https://github.com/snyk/cli/pull/5947).

#### Where should the reviewer start?

From the top!

#### How should this be manually tested?

* `git checkout` the CLI
* `npm install "https://github.com/snyk/snyk-mvn-plugin.git#/dotkas/CLI-193/bump-node-and-shescape" --save`
* * you'll get an `EBADENGINE` warning, as expected, but installation works
* `make build`
* Try and test something with the locally built version, e.g. the CLI repo itself while you're there


#### Any background context you want to provide?

It's a follow-up from https://github.com/snyk/snyk-mvn-plugin/pull/191

#### What are the relevant tickets?

* [CLI-914](https://snyksec.atlassian.net/browse/CLI-194)

#### Screenshots

N/A

#### Additional questions


[CLI-914]: https://snyksec.atlassian.net/browse/CLI-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ