### PR TITLE
feat: [OSM-2667] option for dverbose to include all versions of deps considered by maven

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,6 +35,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
   mavenAggregateProject?: boolean;
+  mavenVerboseIncludeAllVersions?: boolean;
 }
 
 export function getCommand(root: string, targetFile: string | undefined) {
@@ -113,7 +114,12 @@ export async function inspect(
     throw new Error('Could not find file or directory ' + targetPath);
   }
   if (!options) {
-    options = { dev: false, scanAllUnmanaged: false, 'print-graph': false };
+    options = {
+      dev: false,
+      scanAllUnmanaged: false,
+      'print-graph': false,
+      mavenVerboseIncludeAllVersions: false,
+    };
   }
 
   if (targetPath && isArchive(targetPath)) {
@@ -179,6 +185,9 @@ export async function inspect(
     debug(`Maven command: ${mavenCommand} ${mvnArgs.join(' ')}`);
     debug(`Maven working directory: ${mvnWorkingDirectory}`);
     debug(`Verbose enabled: ${verboseEnabled}`);
+    debug(
+      `Verbose enabled with all versions: ${options.mavenVerboseIncludeAllVersions}`,
+    );
     result = await subProcess.execute(mavenCommand, mvnArgs, {
       cwd: mvnWorkingDirectory,
     });
@@ -189,7 +198,12 @@ export async function inspect(
         cwd: mvnWorkingDirectory,
       },
     );
-    const parseResult = parse(result, options.dev, verboseEnabled);
+    const parseResult = parse(
+      result,
+      options.dev,
+      verboseEnabled,
+      options.mavenVerboseIncludeAllVersions,
+    );
     const { javaVersion, mavenVersion } = parseVersions(versionResult);
     const mavenPluginVersion = parsePluginVersionFromStdout(result);
     return {

--- a/lib/parse/index.ts
+++ b/lib/parse/index.ts
@@ -9,9 +9,12 @@ export function parse(
   stdout: string,
   includeTestScope = false,
   verboseEnabled = false,
+  mavenVerboseIncludeAllVersions = false,
 ): { scannedProjects: ScannedProject[] } {
   const digraphs = parseDigraphsFromStdout(stdout);
-  const mavenGraphs = parseDigraphs(digraphs);
+  const mavenGraphs = parseDigraphs(digraphs, {
+    mavenVerboseIncludeAllVersions,
+  });
   const scannedProjects: ScannedProject[] = [];
   for (const mavenGraph of mavenGraphs) {
     const depGraph = buildDepGraph(

--- a/tests/fixtures/dverbose-diff-scopes-versions/expected-dverbose-dep-graph-all-versions.json
+++ b/tests/fixtures/dverbose-diff-scopes-versions/expected-dverbose-dep-graph-all-versions.json
@@ -1,0 +1,102 @@
+{
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "maven"
+    },
+    "pkgs": [
+      {
+        "id": "com.example.scopetest:scope-collision-test@1.0.0",
+        "info": {
+          "name": "com.example.scopetest:scope-collision-test",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "org.slf4j:slf4j-api@1.7.30",
+        "info": {
+          "name": "org.slf4j:slf4j-api",
+          "version": "1.7.30"
+        }
+      },
+      {
+        "id": "ch.qos.logback:logback-classic@1.2.10",
+        "info": {
+          "name": "ch.qos.logback:logback-classic",
+          "version": "1.2.10"
+        }
+      },
+      {
+        "id": "commons-io:commons-io@2.11.0",
+        "info": {
+          "name": "commons-io:commons-io",
+          "version": "2.11.0"
+        }
+      },
+      {
+        "id": "ch.qos.logback:logback-core@1.2.10",
+        "info": {
+          "name": "ch.qos.logback:logback-core",
+          "version": "1.2.10"
+        }
+      },
+      {
+        "id": "org.slf4j:slf4j-api@1.7.32",
+        "info": {
+          "name": "org.slf4j:slf4j-api",
+          "version": "1.7.32"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "com.example.scopetest:scope-collision-test@1.0.0",
+          "deps": [
+            {
+              "nodeId": "org.slf4j:slf4j-api:jar:1.7.30:compile"
+            },
+            {
+              "nodeId": "ch.qos.logback:logback-classic:jar:1.2.10:runtime"
+            },
+            {
+              "nodeId": "commons-io:commons-io:jar:2.11.0:compile"
+            }
+          ]
+        },
+        {
+          "nodeId": "org.slf4j:slf4j-api:jar:1.7.30:compile",
+          "pkgId": "org.slf4j:slf4j-api@1.7.30",
+          "deps": []
+        },
+        {
+          "nodeId": "ch.qos.logback:logback-classic:jar:1.2.10:runtime",
+          "pkgId": "ch.qos.logback:logback-classic@1.2.10",
+          "deps": [
+            {
+              "nodeId": "ch.qos.logback:logback-core:jar:1.2.10:runtime"
+            },
+            {
+              "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:runtime"
+            }
+          ]
+        },
+        {
+          "nodeId": "commons-io:commons-io:jar:2.11.0:compile",
+          "pkgId": "commons-io:commons-io@2.11.0",
+          "deps": []
+        },
+        {
+          "nodeId": "ch.qos.logback:logback-core:jar:1.2.10:runtime",
+          "pkgId": "ch.qos.logback:logback-core@1.2.10",
+          "deps": []
+        },
+        {
+          "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:runtime",
+          "pkgId": "org.slf4j:slf4j-api@1.7.32",
+          "deps": []
+        }
+      ]
+    }
+  }

--- a/tests/fixtures/test-project/expected-verbose-dep-graph-all-versions.json
+++ b/tests/fixtures/test-project/expected-verbose-dep-graph-all-versions.json
@@ -1,0 +1,133 @@
+{
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "maven"
+    },
+    "pkgs": [
+      {
+        "id": "io.snyk.example:test-project@1.0-SNAPSHOT",
+        "info": {
+          "name": "io.snyk.example:test-project",
+          "version": "1.0-SNAPSHOT"
+        }
+      },
+      {
+        "id": "axis:axis@1.4",
+        "info": {
+          "name": "axis:axis",
+          "version": "1.4"
+        }
+      },
+      {
+        "id": "commons-discovery:commons-discovery@0.2",
+        "info": {
+          "name": "commons-discovery:commons-discovery",
+          "version": "0.2"
+        }
+      },
+      {
+        "id": "commons-logging:commons-logging@1.0.3",
+        "info": {
+          "name": "commons-logging:commons-logging",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "commons-logging:commons-logging@1.0.4",
+        "info": {
+          "name": "commons-logging:commons-logging",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "axis:axis-wsdl4j@1.5.1",
+        "info": {
+          "name": "axis:axis-wsdl4j",
+          "version": "1.5.1"
+        }
+      },
+      {
+        "id": "org.apache.axis:axis-saaj@1.4",
+        "info": {
+          "name": "org.apache.axis:axis-saaj",
+          "version": "1.4"
+        }
+      },
+      {
+        "id": "org.apache.axis:axis-jaxrpc@1.4",
+        "info": {
+          "name": "org.apache.axis:axis-jaxrpc",
+          "version": "1.4"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "io.snyk.example:test-project@1.0-SNAPSHOT",
+          "deps": [
+            {
+              "nodeId": "axis:axis:jar:1.4:compile"
+            }
+          ]
+        },
+        {
+          "nodeId": "axis:axis:jar:1.4:compile",
+          "pkgId": "axis:axis@1.4",
+          "deps": [
+            {
+              "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
+            },
+            {
+              "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+            },
+            {
+              "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+            },
+            {
+              "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
+            },
+            {
+              "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
+            }
+          ]
+        },
+        {
+          "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
+          "pkgId": "commons-discovery:commons-discovery@0.2",
+          "deps": [
+            {
+              "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime"
+            }
+          ]
+        },
+        {
+          "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime",
+          "pkgId": "commons-logging:commons-logging@1.0.3",
+          "deps": []
+        },
+        {
+          "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime",
+          "pkgId": "commons-logging:commons-logging@1.0.4",
+          "deps": []
+        },
+        {
+          "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
+          "pkgId": "axis:axis-wsdl4j@1.5.1",
+          "deps": []
+        },
+        {
+          "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
+          "pkgId": "org.apache.axis:axis-saaj@1.4",
+          "deps": []
+        },
+        {
+          "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
+          "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
+          "deps": []
+        }
+      ]
+    }
+  }

--- a/tests/fixtures/verbose-project/expected-verbose-dep-graph-all-versions.json
+++ b/tests/fixtures/verbose-project/expected-verbose-dep-graph-all-versions.json
@@ -1,0 +1,546 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "maven"
+  },
+  "pkgs": [
+    {
+      "id": "io.snyk.example:verbose-project@1.0-SNAPSHOT",
+      "info": {
+        "name": "io.snyk.example:verbose-project",
+        "version": "1.0-SNAPSHOT"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-core@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-core",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "org.yaml:snakeyaml@1.33",
+      "info": {
+        "name": "org.yaml:snakeyaml",
+        "version": "1.33"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-annotations@2.14.2",
+      "info": {
+        "name": "com.fasterxml.jackson.core:jackson-annotations",
+        "version": "2.14.2"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-starter@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-starter",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.yaml:snakeyaml@1.30",
+      "info": {
+        "name": "org.yaml:snakeyaml",
+        "version": "1.30"
+      }
+    },
+    {
+      "id": "org.springframework:spring-core@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-core",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-jcl@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-jcl",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "jakarta.annotation:jakarta.annotation-api@1.3.5",
+      "info": {
+        "name": "jakarta.annotation:jakarta.annotation-api",
+        "version": "1.3.5"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-starter-logging",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.slf4j:jul-to-slf4j@1.7.36",
+      "info": {
+        "name": "org.slf4j:jul-to-slf4j",
+        "version": "1.7.36"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.36",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.36"
+      }
+    },
+    {
+      "id": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
+      "info": {
+        "name": "org.apache.logging.log4j:log4j-to-slf4j",
+        "version": "2.17.2"
+      }
+    },
+    {
+      "id": "org.apache.logging.log4j:log4j-api@2.17.2",
+      "info": {
+        "name": "org.apache.logging.log4j:log4j-api",
+        "version": "2.17.2"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.35",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.35"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-classic@1.2.12",
+      "info": {
+        "name": "ch.qos.logback:logback-classic",
+        "version": "1.2.12"
+      }
+    },
+    {
+      "id": "org.slf4j:slf4j-api@1.7.32",
+      "info": {
+        "name": "org.slf4j:slf4j-api",
+        "version": "1.7.32"
+      }
+    },
+    {
+      "id": "ch.qos.logback:logback-core@1.2.12",
+      "info": {
+        "name": "ch.qos.logback:logback-core",
+        "version": "1.2.12"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot-autoconfigure",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.springframework.boot:spring-boot@2.7.15",
+      "info": {
+        "name": "org.springframework.boot:spring-boot",
+        "version": "2.7.15"
+      }
+    },
+    {
+      "id": "org.springframework:spring-context@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-context",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-expression@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-expression",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-beans@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-beans",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "org.springframework:spring-aop@5.3.29",
+      "info": {
+        "name": "org.springframework:spring-aop",
+        "version": "5.3.29"
+      }
+    },
+    {
+      "id": "axis:axis@1.4",
+      "info": {
+        "name": "axis:axis",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "commons-discovery:commons-discovery@0.2",
+      "info": {
+        "name": "commons-discovery:commons-discovery",
+        "version": "0.2"
+      }
+    },
+    {
+      "id": "commons-logging:commons-logging@1.0.3",
+      "info": {
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.3"
+      }
+    },
+    {
+      "id": "commons-logging:commons-logging@1.0.4",
+      "info": {
+        "name": "commons-logging:commons-logging",
+        "version": "1.0.4"
+      }
+    },
+    {
+      "id": "axis:axis-wsdl4j@1.5.1",
+      "info": {
+        "name": "axis:axis-wsdl4j",
+        "version": "1.5.1"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-saaj@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-saaj",
+        "version": "1.4"
+      }
+    },
+    {
+      "id": "org.apache.axis:axis-jaxrpc@1.4",
+      "info": {
+        "name": "org.apache.axis:axis-jaxrpc",
+        "version": "1.4"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "io.snyk.example:verbose-project@1.0-SNAPSHOT",
+        "deps": [
+          {
+            "nodeId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "axis:axis:jar:1.4:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml@2.14.2",
+        "deps": [
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
+          },
+          {
+            "nodeId": "org.yaml:snakeyaml:jar:1.33:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-core@2.14.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.yaml:snakeyaml:jar:1.33:compile",
+        "pkgId": "org.yaml:snakeyaml@1.33",
+        "deps": []
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-databind@2.14.2",
+        "deps": [
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile"
+          },
+          {
+            "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile",
+        "pkgId": "com.fasterxml.jackson.core:jackson-annotations@2.14.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-starter:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-starter@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.yaml:snakeyaml:jar:1.30:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile"
+          },
+          {
+            "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.yaml:snakeyaml:jar:1.30:compile",
+        "pkgId": "org.yaml:snakeyaml@1.30",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework:spring-core:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-core@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-jcl:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-jcl:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-jcl@5.3.29",
+        "deps": []
+      },
+      {
+        "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile",
+        "pkgId": "jakarta.annotation:jakarta.annotation-api@1.3.5",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-starter-logging:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-starter-logging@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:jul-to-slf4j:jar:1.7.36:compile"
+          },
+          {
+            "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile"
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:jul-to-slf4j:jar:1.7.36:compile",
+        "pkgId": "org.slf4j:jul-to-slf4j@1.7.36",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.36:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.36:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.36",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.logging.log4j:log4j-to-slf4j:jar:2.17.2:compile",
+        "pkgId": "org.apache.logging.log4j:log4j-to-slf4j@2.17.2",
+        "deps": [
+          {
+            "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile"
+          },
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.35:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.apache.logging.log4j:log4j-api:jar:2.17.2:compile",
+        "pkgId": "org.apache.logging.log4j:log4j-api@2.17.2",
+        "deps": []
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.35:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.35",
+        "deps": []
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-classic:jar:1.2.12:compile",
+        "pkgId": "ch.qos.logback:logback-classic@1.2.12",
+        "deps": [
+          {
+            "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile"
+          },
+          {
+            "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.slf4j:slf4j-api:jar:1.7.32:compile",
+        "pkgId": "org.slf4j:slf4j-api@1.7.32",
+        "deps": []
+      },
+      {
+        "nodeId": "ch.qos.logback:logback-core:jar:1.2.12:compile",
+        "pkgId": "ch.qos.logback:logback-core@1.2.12",
+        "deps": []
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot-autoconfigure:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot-autoconfigure@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework.boot:spring-boot:jar:2.7.15:compile",
+        "pkgId": "org.springframework.boot:spring-boot@2.7.15",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-context:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-context:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-context@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-expression:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-expression@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-beans@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "org.springframework:spring-aop:jar:5.3.29:compile",
+        "pkgId": "org.springframework:spring-aop@5.3.29",
+        "deps": [
+          {
+            "nodeId": "org.springframework:spring-core:jar:5.3.29:compile"
+          },
+          {
+            "nodeId": "org.springframework:spring-beans:jar:5.3.29:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "axis:axis:jar:1.4:compile",
+        "pkgId": "axis:axis@1.4",
+        "deps": [
+          {
+            "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime"
+          },
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime"
+          },
+          {
+            "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile"
+          },
+          {
+            "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile"
+          }
+        ]
+      },
+      {
+        "nodeId": "commons-discovery:commons-discovery:jar:0.2:runtime",
+        "pkgId": "commons-discovery:commons-discovery@0.2",
+        "deps": [
+          {
+            "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime"
+          }
+        ]
+      },
+      {
+        "nodeId": "commons-logging:commons-logging:jar:1.0.3:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.3",
+        "deps": []
+      },
+      {
+        "nodeId": "commons-logging:commons-logging:jar:1.0.4:runtime",
+        "pkgId": "commons-logging:commons-logging@1.0.4",
+        "deps": []
+      },
+      {
+        "nodeId": "axis:axis-wsdl4j:jar:1.5.1:runtime",
+        "pkgId": "axis:axis-wsdl4j@1.5.1",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-saaj:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-saaj@1.4",
+        "deps": []
+      },
+      {
+        "nodeId": "org.apache.axis:axis-jaxrpc:jar:1.4:compile",
+        "pkgId": "org.apache.axis:axis-jaxrpc@1.4",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/tests/jest/system/dverbose-flag-all-versions.spec.ts
+++ b/tests/jest/system/dverbose-flag-all-versions.spec.ts
@@ -1,0 +1,265 @@
+import * as plugin from '../../../lib';
+import * as path from 'path';
+import { readFixtureJSON } from '../../helpers/read';
+import * as subProcess from '../../../lib/sub-process';
+import { sortDependencyGraphDeps } from '../../helpers/sort';
+import { DepGraphData } from '@snyk/dep-graph';
+import { legacyPlugin } from '@snyk/cli-interface';
+
+const testsPath = path.join(__dirname, '../..');
+const fixturesPath = path.join(testsPath, 'fixtures');
+const testProjectPath = path.join(fixturesPath, 'dverbose-project');
+const testManagedProjectPath = path.join(
+  fixturesPath,
+  'dverbose-dependency-management',
+);
+const complexProjectPath = path.join(fixturesPath, 'complex-aggregate-project');
+const TESTS_TIMEOUT = 50000;
+
+describe('Dverbose reuturning all considered versions for dependencies tests', () => {
+  test(
+    'inspect on dverbose-project pom using -Dverbose',
+    async () => {
+      const res: Record<string, any> = await plugin.inspect(
+        '.',
+        path.join(testProjectPath, 'pom.xml'),
+        {
+          args: ['-Dverbose'],
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+
+      const expectedJSON: DepGraphData = await readFixtureJSON(
+        'dverbose-project',
+        'expected-dverbose-dep-graph.json',
+      );
+      const result = res.scannedProjects[0].depGraph.toJSON();
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(result);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+      expect(
+        res.plugin.meta.versionBuildInfo.metaBuildVersion.mavenPluginVersion,
+      ).toEqual('3.6.1');
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on dverbose-dependency-management pom using -Dverbose',
+    async () => {
+      const res: Record<string, any> = await plugin.inspect(
+        '.',
+        path.join(testManagedProjectPath, 'pom.xml'),
+        {
+          args: ['-Dverbose'],
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+      const result = res.scannedProjects[0].depGraph.toJSON();
+
+      const expectedJSON = await readFixtureJSON(
+        'dverbose-dependency-management',
+        'expected-dverbose-dep-graph.json',
+      );
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(result);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on dverbose-dependency-management pom using -Dverbose and --dev deps',
+    async () => {
+      const res: Record<string, any> = await plugin.inspect(
+        '.',
+        path.join(testManagedProjectPath, 'pom.xml'),
+        {
+          dev: true,
+          args: ['-Dverbose'],
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+      const result = res.scannedProjects[0].depGraph.toJSON();
+
+      // if running windows with an older version of maven 3.3.9.2 - one of the deps will be omitted
+      const mavenVersion = await subProcess.execute('mvn', ['--version'], {});
+      let expectedJSON = await readFixtureJSON(
+        'dverbose-dependency-management',
+        mavenVersion.includes('3.3.9') && mavenVersion.includes('C:')
+          ? 'expected-dverbose-dep-graph-dev-old-maven.json'
+          : 'expected-dverbose-dep-graph-dev.json',
+      );
+
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(result);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on complext-aggregate-project using -Dverbose and --mavenAggregateProject deps',
+    async () => {
+      let result: Record<string, any> = await plugin.inspect(
+        complexProjectPath,
+        'pom.xml',
+        {
+          args: ['-Dverbose'],
+          mavenAggregateProject: true,
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+
+      let expectedJSON = await readFixtureJSON(
+        'complex-aggregate-project',
+        'verbose-scan-result.json',
+      );
+
+      expect(result.scannedProjects.length).toEqual(
+        expectedJSON.scannedProjects.length,
+      );
+      for (let i = 0; i < result.scannedProjects.length; i++) {
+        const depGraph = result.scannedProjects[i].depGraph.toJSON();
+        const expectedGraphSorted = sortDependencyGraphDeps(
+          expectedJSON.scannedProjects[i].depGraph,
+        );
+        const actualGraphSorted = sortDependencyGraphDeps(depGraph);
+        expect(expectedGraphSorted).toEqual(actualGraphSorted);
+      }
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on dverbose-project pom using --print-graph',
+    async () => {
+      const res: Record<string, any> = await plugin.inspect(
+        '.',
+        path.join(testProjectPath, 'pom.xml'),
+        {
+          'print-graph': true,
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+
+      const expectedJSON = await readFixtureJSON(
+        'dverbose-project',
+        'expected-dverbose-dep-graph.json',
+      );
+      const result = res.scannedProjects[0].depGraph.toJSON();
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(result);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on dverbose-clashing-scopes pom using -Dverbose',
+    async () => {
+      const fixture = 'dverbose-clashing-scopes';
+      const testPath = path.join(fixturesPath, fixture);
+      let res: Record<string, any> = await plugin.inspect(
+        '.',
+        path.join(testPath, 'pom.xml'),
+        {
+          args: ['-Dverbose'],
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+
+      const expectedJSON = await readFixtureJSON(
+        fixture,
+        'expected-dverbose-dep-graph.json',
+      );
+      const result = res.scannedProjects[0].depGraph.toJSON();
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(result);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on dverbose-diff-scopes-versions pom using -Dverbose',
+    async () => {
+      const fixture = 'dverbose-diff-scopes-versions';
+      const testPath = path.join(fixturesPath, fixture);
+      let res: Record<string, any> = await plugin.inspect(
+        '.',
+        path.join(testPath, 'pom.xml'),
+        {
+          args: ['-Dverbose'],
+          mavenVerboseIncludeAllVersions: true,
+        },
+      );
+
+      const expectedJSON = await readFixtureJSON(
+        fixture,
+        'expected-dverbose-dep-graph-all-versions.json',
+      );
+      const result = res.scannedProjects[0].depGraph.toJSON();
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(result);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on test-project pom using -Dverbose',
+    async () => {
+      const fixture = 'test-project';
+      const testPath = path.join(fixturesPath, fixture);
+      const result = await plugin.inspect('.', path.join(testPath, 'pom.xml'), {
+        args: ['-Dverbose'],
+        mavenVerboseIncludeAllVersions: true,
+      });
+      if (!legacyPlugin.isMultiResult(result)) {
+        fail('expected multi inspect result');
+      }
+      expect(result.scannedProjects.length).toEqual(1);
+      const expectedJSON = await readFixtureJSON(
+        'test-project',
+        'expected-verbose-dep-graph-all-versions.json',
+      );
+      const res = result.scannedProjects[0].depGraph?.toJSON();
+      if (!res) {
+        fail('expected dependency graph result');
+      }
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(res);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+
+  test(
+    'inspect on verbose-project pom using -Dverbose',
+    async () => {
+      const fixture = 'verbose-project';
+      const testPath = path.join(fixturesPath, fixture);
+      const result = await plugin.inspect('.', testPath, {
+        args: ['-Dverbose'],
+        mavenVerboseIncludeAllVersions: true,
+      });
+      if (!legacyPlugin.isMultiResult(result)) {
+        return fail('expected multi inspect result');
+      }
+      expect(result.scannedProjects.length).toEqual(1);
+      const expectedJSON = await readFixtureJSON(
+        'verbose-project',
+        'expected-verbose-dep-graph-all-versions.json',
+      );
+      const res = result.scannedProjects[0].depGraph?.toJSON();
+      if (!res) {
+        fail('expected dependency graph result');
+      }
+      const expectedGraphSorted = sortDependencyGraphDeps(expectedJSON);
+      const actualGraphSorted = sortDependencyGraphDeps(res);
+      expect(expectedGraphSorted).toEqual(actualGraphSorted);
+    },
+    TESTS_TIMEOUT,
+  );
+});


### PR DESCRIPTION
#### What does this PR do?

Keeps the default behaviour for dverbose to include in the dep graph only the versions of dependencies that maven resolves to - https://github.com/snyk/snyk-mvn-plugin/pull/190.
Adds an option for dverbose to include in the dep graph all the versions that maven considers for resolution - https://github.com/snyk/snyk-mvn-plugin/pull/189

#### Where should the reviewer start?
Tests, see where the test outputs changed with the new option.
