### PR TITLE
fix: return target file in plugin body

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -196,6 +196,7 @@ export async function inspect(
       plugin: {
         name: 'bundled:maven',
         runtime: 'unknown',
+        targetFile: targetFile,
         meta: {
           versionBuildInfo: {
             metaBuildVersion: {

--- a/tests/jest/system/reactor.spec.ts
+++ b/tests/jest/system/reactor.spec.ts
@@ -146,6 +146,8 @@ test('inspect on complex aggregate project using maven reactor include test scop
       },
     ].sort(byPkgName),
   );
+
+    expect(result.plugin.targetFile).toEqual('pom.xml');
 }, 20000);
 
 test('inspect on complex aggregate project using maven reactor and verbose enabled', async () => {


### PR DESCRIPTION
#### What does this PR do?

Returns the target file so that the cli can store the result when running the snyk monitor command. 
Before: 
![image](https://github.com/user-attachments/assets/33484008-1729-451b-88ff-42cb18e1a684)

After: 
![image](https://github.com/user-attachments/assets/ab52c042-12d0-4a03-a611-e455872bee43)
