### PR TITLE
fix: Uses an actual queue for BFS implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
+    "@common.js/yocto-queue": "^1.1.1",
     "@snyk/cli-interface": "2.11.3",
     "@snyk/dep-graph": "^1.23.1",
     "debug": "^4.3.4",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Quick performance improvement. `Array.shift` is `O(N)` so queue draining is currently `O(N^2)` rather than `O(N)`.

While the size of this queue should never grow too large unlike with verbose which allows node revisiting. This could still be a performance issue for very large projects

#### How should this be manually tested?

Running the local tests. Additionally you can change the `package.json` of the `cli` to point to your local repo of this. Then run `npm install && npm run build-cli:prod` to build the cli using this change. Then use the built version to test the performance on large projects

#### Any background context you want to provide?

See https://github.com/snyk/snyk-gradle-plugin/issues/308 for equivalent change in gradle

We're using `@common.js/yocto-queue` instead of `yocto-queue` as the project is configured to use `commonjs` modules and moving to ES modules would be a larger change
