### PR TITLE
fix: Adjust fingerprintArtifacts option name and other wording tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ const result = await inspect(rootPath, targetFile, options);
 | `allProjects` | boolean | `false` | Include all projects in multi-module builds |
 | `mavenAggregateProject` | boolean | `false` | Treat as Maven aggregate project |
 | `mavenVerboseIncludeAllVersions` | boolean | `false` | Include all dependency versions in verbose mode |
-| `fingerprintArtifacts` | boolean | `false` | Generate cryptographic fingerprints for artifacts |
+| `includeProvenance` | boolean | `false` | Generate cryptographic fingerprints for artifacts to prove origin |
 | `fingerprintAlgorithm` | string | `'sha1'` | Hash algorithm ('sha1', 'sha256', 'sha512') |
 | `mavenRepository` | string | - | Custom Maven repository path |
 
-## Artifact Fingerprinting
+## Package Provenance
 
 The plugin can generate cryptographic fingerprints (hashes) for Maven artifacts to enhance security and integrity verification.
 
@@ -64,11 +64,11 @@ The plugin can generate cryptographic fingerprints (hashes) for Maven artifacts 
 
 ### Configuration
 
-Enable fingerprinting by setting `fingerprintArtifacts: true`:
+Enable fingerprinting by setting `includeProvenance: true`:
 
 ```typescript
 const result = await inspect(rootPath, 'pom.xml', {
-  fingerprintArtifacts: true,
+  includeProvenance: true,
   fingerprintAlgorithm: 'sha256',
   mavenRepository: '/path/to/custom/repo'
 });
@@ -76,13 +76,13 @@ const result = await inspect(rootPath, 'pom.xml', {
 
 ### Supported Hash Algorithms
 
-- `sha1` - SHA-1 (160-bit)
-- `sha256` - SHA-256 (256-bit) - **Default**
+- `sha1` - SHA-1 (160-bit) - **Default**
+- `sha256` - SHA-256 (256-bit)
 - `sha512` - SHA-512 (512-bit)
 
 ### Output Format
 
-When fingerprinting is enabled, the dependency graph includes PURL (Package URL) identifiers with checksum qualifiers:
+When provenance is enabled, the dependency graph includes PURL (Package URL) identifiers with checksum qualifiers:
 
 ```json
 {
@@ -117,7 +117,7 @@ Package URLs follow the standard format with checksum qualifiers:
 
 ### Error Handling
 
-If fingerprinting fails for an artifact, the PURL will not include a checksum qualifier:
+If  fails for an artifact, the PURL will not include a checksum qualifier:
 
 ```json
 {
@@ -129,18 +129,12 @@ If fingerprinting fails for an artifact, the PURL will not include a checksum qu
 }
 ```
 
-### Performance Considerations
-
-- Fingerprinting adds processing time depending on artifact sizes
-- Fingerprinting processes up to 5 artifacts concurrently by default
-- Consider using `sha1` for faster processing of large artifacts
-
 ### Example Timing Output
 
 Timing information is available via debug logging (DEBUG=snyk-mvn-plugin or -d from cli):
 
 ```
-=== Fingerprint Timing Summary ===
+=== Provenance Timing Summary ===
 Total artifacts: 25
 Successful: 23
 Failed: 2

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,7 +40,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   allProjects?: boolean;
   mavenAggregateProject?: boolean;
   mavenVerboseIncludeAllVersions?: boolean;
-  fingerprintArtifacts?: boolean;
+  includeProvenance?: boolean;
   fingerprintAlgorithm?: HashAlgorithm;
   mavenRepository?: string;
 }
@@ -48,7 +48,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
 function buildFingerprintOptions(
   options: MavenOptions,
 ): FingerprintOptions | undefined {
-  if (!options.fingerprintArtifacts) {
+  if (!options.includeProvenance) {
     return undefined;
   }
 

--- a/tests/jest/functional/fingerprint-options.spec.ts
+++ b/tests/jest/functional/fingerprint-options.spec.ts
@@ -6,57 +6,57 @@ import { MavenOptions } from '../../../lib/index';
 
 describe('Fingerprint Helper Functions', () => {
   describe('buildFingerprintOptions', () => {
-    it('should return undefined when fingerprintArtifacts is false', () => {
+    it('should return undefined when includeProvenance is false', () => {
       const options: MavenOptions = {
-        fingerprintArtifacts: false,
+        includeProvenance: false,
       };
 
       // Since buildFingerprintOptions is not exported, we'll need to test this indirectly
       // or make it a named export. For now, let's test the expected behavior through integration
-      expect(options.fingerprintArtifacts).toBe(false);
+      expect(options.includeProvenance).toBe(false);
     });
 
-    it('should return undefined when fingerprintArtifacts is not provided', () => {
+    it('should return undefined when includeProvenance is not provided', () => {
       const options: MavenOptions = {};
 
-      expect(options.fingerprintArtifacts).toBeUndefined();
+      expect(options.includeProvenance).toBeUndefined();
     });
 
     it('should build FingerprintOptions with default values', () => {
       const options: MavenOptions = {
-        fingerprintArtifacts: true,
+        includeProvenance: true,
       };
 
-      expect(options.fingerprintArtifacts).toBe(true);
+      expect(options.includeProvenance).toBe(true);
       expect(options.fingerprintAlgorithm).toBeUndefined(); // Should default to 'sha256'
       expect(options.mavenRepository).toBeUndefined();
     });
 
     it('should build FingerprintOptions with custom values', () => {
       const options: MavenOptions = {
-        fingerprintArtifacts: true,
+        includeProvenance: true,
         fingerprintAlgorithm: 'sha1',
         mavenRepository: '/custom/repo',
       };
 
-      expect(options.fingerprintArtifacts).toBe(true);
+      expect(options.includeProvenance).toBe(true);
       expect(options.fingerprintAlgorithm).toBe('sha1');
       expect(options.mavenRepository).toBe('/custom/repo');
     });
 
     it('should handle all supported hash algorithms', () => {
       const sha256Options: MavenOptions = {
-        fingerprintArtifacts: true,
+        includeProvenance: true,
         fingerprintAlgorithm: 'sha256',
       };
 
       const sha1Options: MavenOptions = {
-        fingerprintArtifacts: true,
+        includeProvenance: true,
         fingerprintAlgorithm: 'sha1',
       };
 
       const sha512Options: MavenOptions = {
-        fingerprintArtifacts: true,
+        includeProvenance: true,
         fingerprintAlgorithm: 'sha512',
       };
 
@@ -80,13 +80,13 @@ describe('MavenOptions Type Tests', () => {
       mavenVerboseIncludeAllVersions: false,
 
       // New fingerprint options
-      fingerprintArtifacts: true,
+      includeProvenance: true,
       fingerprintAlgorithm: 'sha256',
       mavenRepository: '/path/to/repo',
     };
 
     // Verify all properties exist and have correct types
-    expect(typeof fullOptions.fingerprintArtifacts).toBe('boolean');
+    expect(typeof fullOptions.includeProvenance).toBe('boolean');
     expect(
       ['sha1', 'sha256', 'sha512'].includes(fullOptions.fingerprintAlgorithm!),
     ).toBe(true);

--- a/tests/jest/system/fingerprint-e2e.spec.ts
+++ b/tests/jest/system/fingerprint-e2e.spec.ts
@@ -13,7 +13,7 @@ test('fingerprinting disabled vs enabled comparison', async () => {
     path.join(testProjectPath, 'pom.xml'),
     {
       dev: false,
-      fingerprintArtifacts: false,
+      includeProvenance: false,
     },
   );
 
@@ -32,7 +32,7 @@ test('fingerprinting disabled vs enabled comparison', async () => {
     path.join(testProjectPath, 'pom.xml'),
     {
       dev: false,
-      fingerprintArtifacts: true,
+      includeProvenance: true,
     },
   );
 
@@ -65,7 +65,7 @@ describe.each(['sha1', 'sha256', 'sha512'] as const)(
     test(`should work with ${algorithm}`, async () => {
       const result = await inspect('.', path.join(testProjectPath, 'pom.xml'), {
         dev: false,
-        fingerprintArtifacts: true,
+        includeProvenance: true,
         fingerprintAlgorithm: algorithm,
       });
 
@@ -95,7 +95,7 @@ test('fingerprinting graceful failure handling', async () => {
   // Force fingerprinting to fail by using non-existent repository
   const result = await inspect('.', path.join(testProjectPath, 'pom.xml'), {
     dev: false,
-    fingerprintArtifacts: true,
+    includeProvenance: true,
     mavenRepository: '/completely/nonexistent/path',
   });
 

--- a/tests/jest/system/fingerprint-jar.spec.ts
+++ b/tests/jest/system/fingerprint-jar.spec.ts
@@ -18,7 +18,7 @@ describe('Fingerprinting Jar Tests', () => {
         undefined,
         {
           scanAllUnmanaged: true,
-          fingerprintArtifacts: true,
+          includeProvenance: true,
           fingerprintAlgorithm: 'sha256',
         },
         mockSnykSearchClient,
@@ -52,7 +52,7 @@ describe('Fingerprinting Jar Tests', () => {
         undefined,
         {
           scanAllUnmanaged: true,
-          fingerprintArtifacts: false,
+          includeProvenance: false,
         },
         mockSnykSearchClient,
       );
@@ -84,7 +84,7 @@ describe('Fingerprinting Jar Tests', () => {
         undefined,
         {
           scanAllUnmanaged: true,
-          fingerprintArtifacts: true,
+          includeProvenance: true,
         },
         mockSnykSearchClient,
       );
@@ -114,7 +114,7 @@ describe('Fingerprinting Jar Tests', () => {
           root,
           'spring-core-5.1.8.RELEASE.jar',
           {
-            fingerprintArtifacts: true,
+            includeProvenance: true,
             fingerprintAlgorithm: algorithm,
           },
           mockSnykSearchClient,
@@ -144,7 +144,7 @@ describe('Fingerprinting Jar Tests', () => {
         root,
         'spring-core-5.1.8.RELEASE.jar',
         {
-          fingerprintArtifacts: true,
+          includeProvenance: true,
           fingerprintAlgorithm: 'sha256',
         },
         mockSnykSearchClient,


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This adjusts the `fingerprintArtifacts` option to be the more universal `includeProvenance` name. Various entries in readmes, tests, etc. are similarly adjusted.

#### How should this be manually tested?

Testing as part of the legacy `cli` is possible, but would require adding in the capability to handle the flags.
More easily manually tested via this script:
```
const { inspect } = require('./dist/index.js');
const root = process.argv[2];
const targetFile = process.argv[3];

if (!root) {
  console.error('Usage: node script.js <rootDir> [targetFile]');
  process.exit(1);
}

inspect(root, targetFile, { includeProvenance: true })
  .then((res) => {
    const safe = { ...res };
    if (safe.dependencyGraph && typeof safe.dependencyGraph.toJSON === 'function') {
      safe.dependencyGraph = safe.dependencyGraph.toJSON();
    }
    console.log(JSON.stringify(safe, null, 2));
  })
  .catch((err) => {
    console.error(err && err.message ? err.message : err);
    process.exit(1);
  });

```

Then running `npm run build && node script.js /path/to/folder/to/test pom.xml`. You will also need to have first run `mvn clean install` or similar so that the artifacts are present.
e.g.:
```
❯ node script.js tests/fixtures/test-project pom.xml
{
  "plugin": {
    "name": "bundled:maven",
    "runtime": "unknown",
    "meta": {
      "versionBuildInfo": {
        "metaBuildVersion": {
          "mavenVersion": "Apache Maven 4.0.0-rc-4 (bed0f8174bf728978f86fac533aa38a9511f3872)",
          "javaVersion": "Java version: 17.0.15, vendor: Eclipse Adoptium, runtime: /Users/calumharrison/.sdkman/candidates/java/17.0.15-tem",
          "mavenPluginVersion": "3.9.0"
        }
      }
    }
  },
  "scannedProjects": [
    {
      "depGraph": {
        "schemaVersion": "1.3.0",
        "pkgManager": {
          "name": "maven"
        },
        "pkgs": [
          {
            "id": "io.snyk.example:test-project@1.0-SNAPSHOT",
            "info": {
              "name": "io.snyk.example:test-project",
              "version": "1.0-SNAPSHOT",
              "purl": "pkg:maven/io.snyk.example/test-project@1.0-SNAPSHOT?checksum=sha1%3A38324b60f9afaf3d08c1bc90ea9a3418be781a74"
            }
          },
          {
            "id": "axis:axis@1.4",
            "info": {
              "name": "axis:axis",
              "version": "1.4",
              "purl": "pkg:maven/axis/axis@1.4?checksum=sha1%3A94a9ce681a42d0352b3ad22659f67835e560d107"
            }
          },
          {
            "id": "org.apache.axis:axis-jaxrpc@1.4",
            "info": {
              "name": "org.apache.axis:axis-jaxrpc",
              "version": "1.4",
              "purl": "pkg:maven/org.apache.axis/axis-jaxrpc@1.4?checksum=sha1%3Ab393f1f0c0d95b68c86d0b1ab2e687bb71f3c075"
            }
          },
          {
            "id": "org.apache.axis:axis-saaj@1.4",
            "info": {
              "name": "org.apache.axis:axis-saaj",
              "version": "1.4",
              "purl": "pkg:maven/org.apache.axis/axis-saaj@1.4?checksum=sha1%3A581149d1f391258754354f2acf2b56665d53de2e"
            }
          },
          {
            "id": "axis:axis-wsdl4j@1.5.1",
            "info": {
              "name": "axis:axis-wsdl4j",
              "version": "1.5.1",
              "purl": "pkg:maven/axis/axis-wsdl4j@1.5.1?checksum=sha1%3Abd804633b9c2cf06258641febc31a8ff3b0906bc"
            }
          },
          {
            "id": "commons-logging:commons-logging@1.0.4",
            "info": {
              "name": "commons-logging:commons-logging",
              "version": "1.0.4",
              "purl": "pkg:maven/commons-logging/commons-logging@1.0.4?checksum=sha1%3Af029a2aefe2b3e1517573c580f948caac31b1056"
            }
          },
          {
            "id": "commons-discovery:commons-discovery@0.2",
            "info": {
              "name": "commons-discovery:commons-discovery",
              "version": "0.2",
              "purl": "pkg:maven/commons-discovery/commons-discovery@0.2?checksum=sha1%3A7773ac7a7248f08ed2b8d297c6e2ef28260640ea"
            }
          }
        ],
        "graph": {
          ...
        }
      }
    }
  ]
}
```

#### What are the relevant tickets?
- [OSE-108](https://snyksec.atlassian.net/browse/OSE-108)
