### PR TITLE
fix: update error handling and address osx/bash sdkman conflict

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,14 @@ jobs:
       JDK: << parameters.jdk_version >>
     steps:
       - checkout
+      - run:
+          name: Update bash for macOS
+          command: |
+            brew install bash
+            echo 'export PATH="$(brew --prefix bash)/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            which bash
+            bash --version
       - install_sdkman
       - install_jdk_unix:
           jdk_version: << parameters.jdk_version >>
@@ -246,6 +254,14 @@ jobs:
       JDK: << parameters.jdk_version >>
     steps:
       - checkout
+      - run:
+          name: Update bash for macOS
+          command: |
+            brew install bash
+            echo 'export PATH="$(brew --prefix bash)/bin:$PATH"' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            which bash
+            bash --version
       - install_sdkman
       - install_jdk_unix:
           jdk_version: << parameters.jdk_version >>

--- a/lib/maven/dependency-tree.ts
+++ b/lib/maven/dependency-tree.ts
@@ -3,8 +3,8 @@ import * as subProcess from '../sub-process';
 import { debug } from '../index';
 import { parsePluginVersionFromStdout } from '../parse/dependency-tree-parser';
 import { MavenContext } from './context';
-import { DependencyTreeError } from './errors';
 import { MAVEN_DEPENDENCY_PLUGIN_VERSION } from './version';
+import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
 
 export interface MavenDependencyTreeResult {
   dependencyTreeResult: string;
@@ -112,6 +112,17 @@ export async function executeMavenDependencyTree(
       args: mvnArgs,
     };
   } catch (error) {
-    throw new DependencyTreeError(context.command, mvnArgs, error);
+    if (error instanceof Error) {
+      const message = error.message;
+      if (message.includes('Non-parseable POM')) {
+        throw new OpenSourceEcosystems.UnableToParseXMLError(
+          'Error parsing the XML file',
+        );
+      }
+    }
+
+    throw new OpenSourceEcosystems.FailedToBuildMavenProjectError(
+      'Cannot build Maven dependency tree',
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@common.js/yocto-queue": "^1.1.1",
     "@snyk/cli-interface": "2.14.1",
     "@snyk/dep-graph": "^2.12.0",
+    "@snyk/error-catalog-nodejs-public": "^5.79.0",
     "debug": "^4.3.4",
     "glob": "^7.1.6",
     "packageurl-js": "^2.0.1",

--- a/tests/fixtures/bad-xml/pom.xml
+++ b/tests/fixtures/bad-xml/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>bad-test-project</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test project</name>
+  <description>Test project for the Maven CLI plugin</description>
+
+  dependencies>
+
+    <dependency>
+      <groupId>no.such.groupId</groupId>
+      <artifactId>no.such.artifactId</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/tests/jest/system/plugin.spec.ts
+++ b/tests/jest/system/plugin.spec.ts
@@ -138,10 +138,23 @@ describe('plugin.inspect', () => {
       thrownError = error as Error;
     }
 
-    expect(thrownError.message).toMatch(
-      /Child process failed with exit code: [1-9]\d*\./,
-    );
-    expect(thrownError.message).toMatch('there is no POM in this directory');
+    expect(thrownError.message).toMatch('Cannot build Maven dependency tree');
+  });
+
+  test('should throw error when inspecting pom.xml with invalid xml', async () => {
+    let thrownError: Error;
+
+    try {
+      await plugin.inspect('.', path.join(fixturesPath, 'bad-xml', 'pom.xml'), {
+        dev: true,
+      });
+
+      fail('Expected plugin.inspect to throw');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError.message).toMatch('Error parsing the XML file');
   });
 
   test('should throw error when inspecting pom with dependency plugin version less than 2.2', async () => {
@@ -181,10 +194,7 @@ describe('plugin.inspect', () => {
       );
     } catch (err) {
       if (err instanceof Error) {
-        expect(err.message).toMatch('BUILD FAILURE');
-        expect(err.message).toMatch(
-          'no.such.groupId:no.such.artifactId:jar:1.0.0',
-        );
+        expect(err.message).toMatch('Cannot build Maven dependency tree');
       } else {
         throw new Error('error is not instance of Error');
       }
@@ -241,18 +251,7 @@ describe('plugin.inspect', () => {
         );
       } catch (err) {
         if (err instanceof Error) {
-          const expectedCommand =
-            '\n\n' +
-            'Please make sure that Apache Maven Dependency Plugin ' +
-            'version 2.2 or above is installed, and that `' +
-            fullCommand +
-            '` executes successfully ' +
-            'on this project.\n\n' +
-            'If the problem persists, collect the output of `' +
-            'DEBUG=* ' +
-            fullCommand +
-            '` and contact support@snyk.io\n';
-          expect(err.message).toMatch(expectedCommand);
+          expect(err.message).toMatch('Cannot build Maven dependency tree');
         } else {
           throw new Error('error is not instance of Error');
         }
@@ -273,9 +272,7 @@ describe('plugin.inspect', () => {
       }),
     ).rejects.toThrow(
       expect.objectContaining({
-        message: expect.stringMatching(
-          '\\[WARNING\\] The POM for no.such.groupId:no.such.artifactId:jar:1.0.0 is missing, no dependency information available',
-        ),
+        message: expect.stringMatching('Cannot build Maven dependency tree'),
       }),
     );
   });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Update error handling to return catalog errors to end user
Updated bash in osx circleci to support sdkman

#### Where should the reviewer start?
Review error handling in the dependency tree

#### How should this be manually tested?
Running cli with several pom.xml errors i.e invalid xml, missing required version etc..

#### Any background context you want to provide?
Part of general update to provide more meaningful error codes to end user.


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CSENG-179


