### PR TITLE
feat: add mavenDebugOutput option for logging raw Maven command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ const result = await inspect(rootPath, targetFile, options);
 | `allProjects` | boolean | `false` | Include all projects in multi-module builds |
 | `mavenAggregateProject` | boolean | `false` | Treat as Maven aggregate project |
 | `mavenVerboseIncludeAllVersions` | boolean | `false` | Include all dependency versions in verbose mode |
+| `mavenDebugOutput` | boolean | `false` | Log raw Maven command output to debug |
 | `includeProvenance` | boolean | `false` | Generate cryptographic fingerprints for artifacts to prove origin |
 | `fingerprintAlgorithm` | string | `'sha1'` | Hash algorithm ('sha1', 'sha256', 'sha512') |
 | `mavenRepository` | string | - | Custom Maven repository path |

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,6 +45,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   mavenRepository?: string;
   showMavenBuildScope?: boolean;
   mavenSkipWrapper?: boolean;
+  mavenDebugOutput?: boolean;
 }
 
 function buildFingerprintOptions(
@@ -79,6 +80,7 @@ export async function inspect(
       scanAllUnmanaged: false,
       'print-graph': false,
       mavenVerboseIncludeAllVersions: false,
+      mavenDebugOutput: false,
     };
   }
   const fingerprintOptions = buildFingerprintOptions(options);
@@ -138,6 +140,8 @@ export async function inspect(
     args.includes('-Dverbose=true') ||
     !!options['print-graph'];
 
+  const logMavenOutput = !!options.mavenDebugOutput;
+
   let executionResult;
   try {
     // Execute Maven pipeline (resolve + tree)
@@ -146,6 +150,7 @@ export async function inspect(
       options.mavenAggregateProject,
       verboseEnabled,
       args,
+      logMavenOutput,
     );
     debug(
       `Verbose enabled with all versions: ${options.mavenVerboseIncludeAllVersions}`,
@@ -193,7 +198,7 @@ export async function inspect(
       ...{ scannedProjects },
     };
   } catch (err) {
-    if (executionResult) {
+    if (executionResult && !logMavenOutput) {
       debug(`>>> Output from mvn: ${executionResult.dependencyTreeResult}`);
     }
 

--- a/lib/maven/dependency-resolve.ts
+++ b/lib/maven/dependency-resolve.ts
@@ -4,6 +4,12 @@ import { debug } from '../index';
 import { MavenContext } from './context';
 import { MAVEN_DEPENDENCY_PLUGIN_VERSION } from './version';
 
+export interface MavenDependencyResolveResult {
+  dependencyResolveResult: string;
+  command: string;
+  args: string[];
+}
+
 export function buildArgs(
   context: MavenContext,
   mavenArgs: string[],
@@ -55,7 +61,7 @@ export async function executeMavenDependencyResolve(
   mavenAggregateProject: boolean,
   args: string[],
   pluginVersion: string = MAVEN_DEPENDENCY_PLUGIN_VERSION,
-): Promise<string> {
+): Promise<MavenDependencyResolveResult> {
   const mvnArgs = buildArgs(
     context,
     args,
@@ -67,9 +73,19 @@ export async function executeMavenDependencyResolve(
   debug(`Maven working directory: ${context.workingDirectory}`);
 
   try {
-    return await subProcess.execute(context.command, mvnArgs, {
-      cwd: context.workingDirectory,
-    });
+    const dependencyResolveResult = await subProcess.execute(
+      context.command,
+      mvnArgs,
+      {
+        cwd: context.workingDirectory,
+      },
+    );
+
+    return {
+      dependencyResolveResult,
+      command: context.command,
+      args: mvnArgs,
+    };
   } catch (error) {
     debug(
       `dependency:resolve execution failed - command: ${

--- a/lib/maven/executor.ts
+++ b/lib/maven/executor.ts
@@ -1,4 +1,7 @@
-import { executeMavenDependencyResolve } from './dependency-resolve';
+import {
+  executeMavenDependencyResolve,
+  MavenDependencyResolveResult,
+} from './dependency-resolve';
 import { executeMavenDependencyTree } from './dependency-tree';
 import { MavenContext } from './context';
 import { getMavenVersion, selectPluginVersion } from './version';
@@ -33,6 +36,22 @@ export interface MavenExecutionResult {
   args: string[];
 }
 
+function logMavenCommandOutput(
+  phase: string,
+  command: string,
+  args: string[],
+  output: string,
+) {
+  if (!output) {
+    debug(
+      `>>> Maven ${phase} output (${command} ${args.join(' ')}): <no output>`,
+    );
+    return;
+  }
+
+  debug(`>>> Maven ${phase} output (${command} ${args.join(' ')}):`, output);
+}
+
 /**
  * Execute the optimal Maven pipeline: dependency:tree (required) + dependency:resolve (conditional)
  *
@@ -44,6 +63,7 @@ export async function executeMavenPipeline(
   mavenAggregateProject = false,
   verboseEnabled: boolean,
   args: string[],
+  logMavenOutput = false,
 ): Promise<MavenExecutionResult> {
   // Get Maven version to select appropriate maven-dependency-plugin version
   // This is used for verbose mode (dependency:tree) and dependency:resolve
@@ -61,6 +81,15 @@ export async function executeMavenPipeline(
     explicitPluginVersion,
   );
 
+  if (logMavenOutput) {
+    logMavenCommandOutput(
+      'dependency:tree',
+      treeResult.command,
+      treeResult.args,
+      treeResult.dependencyTreeResult,
+    );
+  }
+
   const hasMetaversions = detectMetaversions(treeResult.dependencyTreeResult);
   debug(`Metaversions detected: ${hasMetaversions}`);
 
@@ -69,16 +98,29 @@ export async function executeMavenPipeline(
   if (hasMetaversions) {
     try {
       debug('Running dependency:resolve for metaversion resolution');
-      const resolveResult = await executeMavenDependencyResolve(
-        context,
-        mavenAggregateProject,
-        args,
-        explicitPluginVersion,
-      );
-      debug(`Resolve result: ${resolveResult}`);
+      const resolveResult: MavenDependencyResolveResult =
+        await executeMavenDependencyResolve(
+          context,
+          mavenAggregateProject,
+          args,
+          explicitPluginVersion,
+        );
+
+      if (logMavenOutput) {
+        logMavenCommandOutput(
+          'dependency:resolve',
+          resolveResult.command,
+          resolveResult.args,
+          resolveResult.dependencyResolveResult,
+        );
+      } else {
+        debug(`Resolve result: ${resolveResult.dependencyResolveResult}`);
+      }
 
       // Parse immediately and fail fast if there's an issue
-      versionResolver = createVersionResolver(resolveResult);
+      versionResolver = createVersionResolver(
+        resolveResult.dependencyResolveResult,
+      );
     } catch (err) {
       debug(`Version resolution failed: ${err}`);
       // Graceful degradation using no-op version resolver

--- a/tests/jest/functional/maven/executor.spec.ts
+++ b/tests/jest/functional/maven/executor.spec.ts
@@ -1,4 +1,5 @@
 import { executeMavenPipeline } from '../../../../lib/maven/executor';
+import * as plugin from '../../../../lib';
 import * as dependencyTree from '../../../../lib/maven/dependency-tree';
 import * as dependencyResolve from '../../../../lib/maven/dependency-resolve';
 import * as version from '../../../../lib/maven/version';
@@ -98,9 +99,13 @@ describe('executeMavenPipeline conditional logic', () => {
     });
 
     // Mock resolve result with resolved versions
-    mockExecuteMavenDependencyResolve.mockResolvedValue(`[INFO] The following files have been resolved:
+    mockExecuteMavenDependencyResolve.mockResolvedValue({
+      dependencyResolveResult: `[INFO] The following files have been resolved:
 [INFO]    junit:junit:jar:4.13.2:test -- module junit [auto]
-[INFO]    org.slf4j:slf4j-api:jar:1.7.36:compile -- module org.slf4j.api`);
+[INFO]    org.slf4j:slf4j-api:jar:1.7.36:compile -- module org.slf4j.api`,
+      command: 'mvn',
+      args: ['dependency:resolve', '--batch-mode'],
+    });
 
     const result = await executeMavenPipeline(context, false, false, []);
 
@@ -167,8 +172,12 @@ describe('executeMavenPipeline conditional logic', () => {
       args: ['test-compile', 'dependency:tree', '--batch-mode'],
     });
 
-    mockExecuteMavenDependencyResolve.mockResolvedValue(`[INFO] The following files have been resolved:
-[INFO]    com.example:module-a:jar:1.0.0:compile -- module com.example.module.a`);
+    mockExecuteMavenDependencyResolve.mockResolvedValue({
+      dependencyResolveResult: `[INFO] The following files have been resolved:
+[INFO]    com.example:module-a:jar:1.0.0:compile -- module com.example.module.a`,
+      command: 'mvn',
+      args: ['dependency:resolve', '--batch-mode'],
+    });
 
     const result = await executeMavenPipeline(context, true, false, [
       '-Pprofile',
@@ -191,5 +200,41 @@ describe('executeMavenPipeline conditional logic', () => {
     );
 
     expect(result.versionResolver).not.toBe(NO_OP_VERSION_RESOLVER);
+  });
+
+  test('should log mvn output when requested', async () => {
+    mockExecuteMavenDependencyTree.mockResolvedValue({
+      dependencyTreeResult: `digraph "com.example:test:jar:1.0.0" {
+"com.example:test:jar:1.0.0" -> "junit:junit:jar:RELEASE:test" ;
+}`,
+      command: 'mvn',
+      args: ['dependency:tree', '--batch-mode'],
+    });
+
+    mockExecuteMavenDependencyResolve.mockResolvedValue({
+      dependencyResolveResult: `[INFO] Resolved artifacts
+[INFO] junit:junit:jar:4.13.2:test`,
+      command: 'mvn',
+      args: ['dependency:resolve', '--batch-mode'],
+    });
+
+    const debugSpy = jest
+      .spyOn(plugin, 'debug')
+      .mockImplementation(() => undefined);
+
+    try {
+      await executeMavenPipeline(context, false, false, [], true);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dependency:tree output'),
+        expect.stringContaining('digraph "com.example:test:jar:1.0.0"'),
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dependency:resolve output'),
+        expect.stringContaining('Resolved artifacts'),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Introduced `mavenDebugOutput` boolean option to enable logging of raw Maven command output during execution.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Introduces a new flag (mavenDebugOutput) to print maven stdout/stderr with snyk --debug is being used. 

I created this after debugging an issue with maven caching. It was hard to tell if snyk was caching the output or not.It's not possible to tell if caching is being used right now without running maven commands by hand which can be difficult in CI situations. This is what the output looks like:
```
2026-03-25T03:39:51.878Z snyk-mvn-plugin Child process exited with code: 0
2026-03-25T03:39:51.878Z snyk-mvn-plugin Maven version: Apache Maven 3.9.12 (848fbb4bf2d427b72bdb2471c22fced7ebd9a7a1), explicit plugin version: 3.9.0
2026-03-25T03:39:51.879Z snyk-mvn-plugin Maven command: mvn dependency:tree -DoutputType=dot --batch-mode --non-recursive --file pom.xml
2026-03-25T03:39:51.879Z snyk-mvn-plugin Maven working directory: /Users/ianzink/git/maven-monorepo-example
2026-03-25T03:39:51.879Z snyk-mvn-plugin Verbose enabled: false
2026-03-25T03:39:53.583Z snyk-mvn-plugin Child process exited with code: 0
2026-03-25T03:39:53.583Z snyk-mvn-plugin >>> Maven dependency:tree output (mvn dependency:tree -DoutputType=dot --batch-mode --non-recursive --file pom.xml):
2026-03-25T03:39:53.583Z snyk-mvn-plugin [INFO] Scanning for projects...
[INFO]
[INFO] -----------------< org.example:maven-monorepo-example >-----------------
[INFO] Building maven-monorepo-example 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ maven-monorepo-example ---
[INFO] digraph "org.example:maven-monorepo-example:pom:1.0-SNAPSHOT" {
[INFO]  }
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.776 s
[INFO] Finished at: 2026-03-25T14:39:53+11:00
[INFO] ------------------------------------------------------------------------

2026-03-25T03:39:53.583Z snyk-mvn-plugin Metaversions detected: false
2026-03-25T03:39:53.583Z snyk-mvn-plugin No metaversions detected - using no-op resolver for optimal performance
```

#### Where should the reviewer start?


#### How should this be manually tested?
Run `snyk test --mavenDebugOutput --debug` see the maven output displayed.

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
