### PR TITLE
fix: propagate Maven error detail instead of hardcoded message [CSENG…

### DIFF
--- a/lib/maven/dependency-tree.ts
+++ b/lib/maven/dependency-tree.ts
@@ -115,14 +115,12 @@ export async function executeMavenDependencyTree(
     if (error instanceof Error) {
       const message = error.message;
       if (message.includes('Non-parseable POM')) {
-        throw new OpenSourceEcosystems.UnableToParseXMLError(
-          'Error parsing the XML file',
-        );
+        throw new OpenSourceEcosystems.UnableToParseXMLError(message);
       }
     }
 
-    throw new OpenSourceEcosystems.FailedToBuildMavenProjectError(
-      'Cannot build Maven dependency tree',
-    );
+    const detail =
+      error instanceof Error ? error.message : 'Cannot build Maven dependency tree';
+    throw new OpenSourceEcosystems.FailedToBuildMavenProjectError(detail);
   }
 }


### PR DESCRIPTION

- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Propagates the original Maven error detail (file path, line number, column, syntax error description) through `UnableToParseXMLError` and `FailedToBuildMavenProjectError` instead of discarding it and substituting hardcoded strings.

#### Where should the reviewer start?

`lib/maven/dependency-tree.ts` — the catch block in `executeMavenDependencyTree`.

#### How should this be manually tested?

Run `snyk sbom --format=cyclonedx1.5+json` against a project with a malformed `pom.xml` (e.g. a missing `>` on a closing tag). The error output should now include the specific Maven parse error with line/column info rather than just "Error parsing the XML file".

#### Any background context you want to provide?

Commit `e6918d9` (PR #214, v4.6.1) replaced `DependencyTreeError` with error catalog types but hardcoded the detail strings, discarding the original Maven stderr/stdout. This caused a regression where users lost actionable diagnostics — the error code changed from SNYK-CLI-0011 (which included full Maven output) to SNYK-OS-MAVEN-0005 (which only showed "Error parsing the XML file" with no location info).

#### What are the relevant tickets?

CSENG-202

#### Screenshots

**Before (v4.6.1 — hardcoded message):**
```
ERROR   Error parsing the XML file (SNYK-OS-MAVEN-0005)

          Error parsing the XML file

Status:  422 Unprocessable Entity
```

**After (this fix — propagated detail):**
```
ERROR   Error parsing the XML file (SNYK-OS-MAVEN-0005)

          Child process failed with exit code: 1.
          STDOUT:
          [FATAL] Non-parseable POM /path/to/pom.xml: expected > to finish end tag
          not < from line 6 (position: TEXT seen ...) @ line 7, column 6
```

#### Additional questions

None.
