### PR TITLE
feat: SBOM package hashes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,7 +14,11 @@ import { formatGenericPluginError } from './error-format';
 import * as debugModule from 'debug';
 import { parseMavenDependencyTree } from './parse/dependency-tree-parser';
 import { buildScannedProjects } from './parse/scanned-project-builder';
-import { generateMavenFingerprints } from './fingerprint';
+import {
+  generateMavenFingerprints,
+  getMavenRepositoryPath,
+} from './fingerprint';
+import { buildM2HashLabelsMap } from './parse/m2-hash-labels';
 import {
   SnykHttpClient,
   HashAlgorithm,
@@ -41,6 +45,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   mavenAggregateProject?: boolean;
   mavenVerboseIncludeAllVersions?: boolean;
   includeProvenance?: boolean;
+  includeHashes?: boolean;
   fingerprintAlgorithm?: HashAlgorithm;
   mavenRepository?: string;
   showMavenBuildScope?: boolean;
@@ -166,6 +171,18 @@ export async function inspect(
       );
     }
 
+    // Read install-time-recorded companion-file hashes (e.g. `.jar.sha1`) from
+    // the local Maven repository and surface them as `hash:<algorithm>` labels.
+    // Gated behind its own `--include-hashes` option for now.
+    let hashLabelsMap = new Map<string, Record<string, string>>();
+    if (options.includeHashes) {
+      const repositoryPath = await getMavenRepositoryPath(
+        mavenContext.command,
+        options.mavenRepository,
+      );
+      hashLabelsMap = await buildM2HashLabelsMap(mavenGraphs, repositoryPath);
+    }
+
     // Build scanned projects
     const { scannedProjects } = buildScannedProjects(
       mavenGraphs,
@@ -174,6 +191,7 @@ export async function inspect(
       fingerprintMap,
       !!fingerprintOptions?.enabled,
       !!options.showMavenBuildScope,
+      hashLabelsMap,
     );
 
     return {

--- a/lib/parse/dep-graph.ts
+++ b/lib/parse/dep-graph.ts
@@ -147,14 +147,24 @@ function createNodeInfo(
   context: ParseContext,
   defaultScope = 'compile',
 ): NodeInfo | undefined {
+  const labels: Record<string, string> = {};
+
   if (context.showMavenBuildScope) {
-    return {
-      labels: {
-        'maven:build_scope': depInfo.scope ? depInfo.scope : defaultScope,
-      },
-    };
+    labels['maven:build_scope'] = depInfo.scope ? depInfo.scope : defaultScope;
   }
-  return;
+
+  // Merge install-time-recorded hash labels (read from `.m2/.../*.sha1` etc.
+  // companion files). These are consumed downstream by sbom-export to populate
+  // CycloneDX `component.Hashes` / SPDX `Package.PackageChecksums`.
+  const hashLabels = context.hashLabelsMap?.get(depInfo.id);
+  if (hashLabels) {
+    Object.assign(labels, hashLabels);
+  }
+
+  if (Object.keys(labels).length === 0) {
+    return;
+  }
+  return { labels };
 }
 
 interface QueueItem {

--- a/lib/parse/dep-graph.ts
+++ b/lib/parse/dep-graph.ts
@@ -154,8 +154,8 @@ function createNodeInfo(
   }
 
   // Merge install-time-recorded hash labels (read from `.m2/.../*.sha1` etc.
-  // companion files). These are consumed downstream by sbom-export to populate
-  // CycloneDX `component.Hashes` / SPDX `Package.PackageChecksums`.
+  // companion files). These are consumed downstream to populate CycloneDX
+  // `component.Hashes` / SPDX `Package.PackageChecksums`.
   const hashLabels = context.hashLabelsMap?.get(depInfo.id);
   if (hashLabels) {
     Object.assign(labels, hashLabels);

--- a/lib/parse/m2-hash-labels.ts
+++ b/lib/parse/m2-hash-labels.ts
@@ -14,8 +14,10 @@ import { debug } from '../index';
  * Maven received.
  *
  * This module reads those files (no hashing happens here) and surfaces the
- * contents as depgraph labels keyed by `hash:<algorithm>` (using CycloneDX-style
- * algorithm names) for consumption by sbom-export.
+ * contents as depgraph labels keyed by `hash:<algorithm>`, where `<algorithm>`
+ * is a lowercase-normalized name (`md5`, `sha-1`, `sha-256`, `sha-512`). The
+ * downstream consumer maps these to the CycloneDX/SPDX algorithm names it
+ * requires.
  */
 
 // Maps Maven companion-file extensions to the CycloneDX/SBOM hash-algorithm
@@ -35,9 +37,18 @@ const M2_COMPANION_FILES: {
   { ext: 'sha512', algorithm: 'sha-512', digestPattern: /^[0-9a-f]{128}$/ },
 ];
 
-// Number of artifacts whose companion files are read concurrently. Matches the
-// concurrency limit used by `generateFingerprints` in fingerprint.ts.
+// Number of artifacts processed per batch. Each artifact reads its companion
+// files concurrently (up to one per entry in M2_COMPANION_FILES), so up to
+// CONCURRENCY * M2_COMPANION_FILES.length companion reads are in flight at once.
 const CONCURRENCY = 5;
+
+// Upper bound on the bytes read from a companion file. We only keep the first
+// whitespace-delimited token, and the longest valid digest is sha-512 at 128
+// hex chars; 256 bytes leaves slack for a leading BOM/whitespace while still
+// reaching that token. Reading a small prefix rather than the whole file stops
+// a misconfigured mirror that stored a large HTML error page from being
+// buffered wholesale — anything past the first token is irrelevant.
+const MAX_COMPANION_BYTES = 256;
 
 /**
  * Read a single companion-file value. Returns undefined if the file does not
@@ -57,12 +68,18 @@ async function readCompanionFile(
 ): Promise<string | undefined> {
   const companionPath = `${artifactPath}.${ext}`;
   let raw: string;
+  let handle: fs.promises.FileHandle | undefined;
   try {
-    raw = (await fs.promises.readFile(companionPath, 'utf8')).trim();
+    handle = await fs.promises.open(companionPath, 'r');
+    const buffer = Buffer.alloc(MAX_COMPANION_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, MAX_COMPANION_BYTES, 0);
+    raw = buffer.toString('utf8', 0, bytesRead).trim();
   } catch {
     // File does not exist (older artifacts may not publish every algorithm) or
     // is unreadable — treat both as "no recorded hash for this algorithm".
     return undefined;
+  } finally {
+    await handle?.close();
   }
   const digest = raw.split(/\s+/, 1)[0].toLowerCase();
   if (!digestPattern.test(digest)) {

--- a/lib/parse/m2-hash-labels.ts
+++ b/lib/parse/m2-hash-labels.ts
@@ -26,18 +26,29 @@ const M2_COMPANION_FILES: { ext: string; algorithm: string }[] = [
   { ext: 'sha512', algorithm: 'sha-512' },
 ];
 
+// Number of artifacts whose companion files are read concurrently. Matches the
+// concurrency limit used by `generateFingerprints` in fingerprint.ts.
+const CONCURRENCY = 5;
+
 /**
  * Read a single companion-file value. Returns undefined if the file does not
  * exist (older artifacts may not publish SHA-256/SHA-512). Returns the raw
  * hex digest, lowercased — Maven companion files contain the digest as ASCII
  * hex, sometimes followed by a space and the filename; we keep only the digest.
  */
-function readCompanionFile(artifactPath: string, ext: string): string | undefined {
+async function readCompanionFile(
+  artifactPath: string,
+  ext: string,
+): Promise<string | undefined> {
   const companionPath = `${artifactPath}.${ext}`;
-  if (!fs.existsSync(companionPath)) {
+  let raw: string;
+  try {
+    raw = (await fs.promises.readFile(companionPath, 'utf8')).trim();
+  } catch {
+    // File does not exist (older artifacts may not publish every algorithm) or
+    // is unreadable — treat both as "no recorded hash for this algorithm".
     return undefined;
   }
-  const raw = fs.readFileSync(companionPath, 'utf8').trim();
   // Maven sometimes formats as `<hex>  <filename>`; the first whitespace-delimited
   // token is the digest. Normalise to lowercase for a stable label value.
   const digest = raw.split(/\s+/, 1)[0];
@@ -52,19 +63,23 @@ function readCompanionFile(artifactPath: string, ext: string): string | undefine
  * Empty result if none are present (artifact not in .m2 yet, or no companion
  * files published).
  */
-export function readM2HashLabels(
+export async function readM2HashLabels(
   dependencyId: string,
   repositoryPath: string,
-): Record<string, string> {
+): Promise<Record<string, string>> {
   const labels: Record<string, string> = {};
   const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
 
-  for (const { ext, algorithm } of M2_COMPANION_FILES) {
-    const digest = readCompanionFile(artifactPath, ext);
+  const digests = await Promise.all(
+    M2_COMPANION_FILES.map(({ ext }) => readCompanionFile(artifactPath, ext)),
+  );
+
+  M2_COMPANION_FILES.forEach(({ algorithm }, i) => {
+    const digest = digests[i];
     if (digest) {
       labels[`hash:${algorithm}`] = digest;
     }
-  }
+  });
 
   return labels;
 }
@@ -72,24 +87,34 @@ export function readM2HashLabels(
 /**
  * Pre-compute the hash-label map for every node in a set of Maven graphs.
  * Mirrors the pattern used by `generateFingerprints` so the depgraph builder
- * can attach labels without doing I/O inside the BFS/DFS loop.
+ * can attach labels without doing I/O inside the BFS/DFS loop. Reads are run
+ * asynchronously in bounded batches so they never block the event loop.
  */
-export function buildM2HashLabelsMap(
+export async function buildM2HashLabelsMap(
   mavenGraphs: MavenGraph[],
   repositoryPath: string,
-): Map<string, Record<string, string>> {
+): Promise<Map<string, Record<string, string>>> {
   const result = new Map<string, Record<string, string>>();
-  const seen = new Set<string>();
 
+  // Collect the unique node IDs across all graphs.
+  const nodeIds = new Set<string>();
   for (const graph of mavenGraphs) {
-    for (const nodeId of Object.keys(graph.nodes)) {
-      if (seen.has(nodeId)) continue;
-      seen.add(nodeId);
-      const labels = readM2HashLabels(nodeId, repositoryPath);
+    Object.keys(graph.nodes).forEach((nodeId) => nodeIds.add(nodeId));
+  }
+  const nodeIdArray = Array.from(nodeIds);
+
+  // Read companion files in bounded-concurrency batches.
+  for (let i = 0; i < nodeIdArray.length; i += CONCURRENCY) {
+    const batch = nodeIdArray.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map((nodeId) => readM2HashLabels(nodeId, repositoryPath)),
+    );
+    batch.forEach((nodeId, j) => {
+      const labels = batchResults[j];
       if (Object.keys(labels).length > 0) {
         result.set(nodeId, labels);
       }
-    }
+    });
   }
 
   return result;

--- a/lib/parse/m2-hash-labels.ts
+++ b/lib/parse/m2-hash-labels.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import type { MavenGraph } from './types';
+import { dependencyIdToArtifactPath } from '../fingerprint';
+
+/**
+ * Read install-time-recorded hashes from the Maven local repository.
+ *
+ * For each artifact in `~/.m2/repository/.../`, Maven stores the JAR alongside
+ * companion checksum files (`<artifact>.jar.sha1`, `.md5`, `.sha256`, sometimes
+ * `.sha512`). Those files came from the upstream Maven repository at install
+ * time and Maven verified them against the JAR bytes before saving. They are
+ * therefore the install-time-recorded hash of the artifact the customer's
+ * Maven received.
+ *
+ * This module reads those files (no hashing happens here) and surfaces the
+ * contents as depgraph labels keyed by `hash:<algorithm>` (using CycloneDX-style
+ * algorithm names) for consumption by sbom-export.
+ */
+
+// Maps Maven companion-file extensions to the CycloneDX/SBOM hash-algorithm
+// label suffix. The label key emitted is `hash:<suffix>`.
+const M2_COMPANION_FILES: { ext: string; algorithm: string }[] = [
+  { ext: 'md5', algorithm: 'md5' },
+  { ext: 'sha1', algorithm: 'sha-1' },
+  { ext: 'sha256', algorithm: 'sha-256' },
+  { ext: 'sha512', algorithm: 'sha-512' },
+];
+
+/**
+ * Read a single companion-file value. Returns undefined if the file does not
+ * exist (older artifacts may not publish SHA-256/SHA-512). Returns the raw
+ * hex digest, lowercased — Maven companion files contain the digest as ASCII
+ * hex, sometimes followed by a space and the filename; we keep only the digest.
+ */
+function readCompanionFile(artifactPath: string, ext: string): string | undefined {
+  const companionPath = `${artifactPath}.${ext}`;
+  if (!fs.existsSync(companionPath)) {
+    return undefined;
+  }
+  const raw = fs.readFileSync(companionPath, 'utf8').trim();
+  // Maven sometimes formats as `<hex>  <filename>`; the first whitespace-delimited
+  // token is the digest. Normalise to lowercase for a stable label value.
+  const digest = raw.split(/\s+/, 1)[0];
+  return digest.toLowerCase();
+}
+
+/**
+ * Given a Maven dependency ID (e.g. "com.google.guava:guava:jar:32.1.3-jre"),
+ * read whichever companion checksum files exist for it in the local Maven
+ * repository and return them as `hash:<algorithm>` -> hex labels.
+ *
+ * Empty result if none are present (artifact not in .m2 yet, or no companion
+ * files published).
+ */
+export function readM2HashLabels(
+  dependencyId: string,
+  repositoryPath: string,
+): Record<string, string> {
+  const labels: Record<string, string> = {};
+  const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
+
+  for (const { ext, algorithm } of M2_COMPANION_FILES) {
+    const digest = readCompanionFile(artifactPath, ext);
+    if (digest) {
+      labels[`hash:${algorithm}`] = digest;
+    }
+  }
+
+  return labels;
+}
+
+/**
+ * Pre-compute the hash-label map for every node in a set of Maven graphs.
+ * Mirrors the pattern used by `generateFingerprints` so the depgraph builder
+ * can attach labels without doing I/O inside the BFS/DFS loop.
+ */
+export function buildM2HashLabelsMap(
+  mavenGraphs: MavenGraph[],
+  repositoryPath: string,
+): Map<string, Record<string, string>> {
+  const result = new Map<string, Record<string, string>>();
+  const seen = new Set<string>();
+
+  for (const graph of mavenGraphs) {
+    for (const nodeId of Object.keys(graph.nodes)) {
+      if (seen.has(nodeId)) continue;
+      seen.add(nodeId);
+      const labels = readM2HashLabels(nodeId, repositoryPath);
+      if (Object.keys(labels).length > 0) {
+        result.set(nodeId, labels);
+      }
+    }
+  }
+
+  return result;
+}

--- a/lib/parse/m2-hash-labels.ts
+++ b/lib/parse/m2-hash-labels.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import type { MavenGraph } from './types';
 import { dependencyIdToArtifactPath } from '../fingerprint';
+import { debug } from '../index';
 
 /**
  * Read install-time-recorded hashes from the Maven local repository.
@@ -18,12 +19,20 @@ import { dependencyIdToArtifactPath } from '../fingerprint';
  */
 
 // Maps Maven companion-file extensions to the CycloneDX/SBOM hash-algorithm
-// label suffix. The label key emitted is `hash:<suffix>`.
-const M2_COMPANION_FILES: { ext: string; algorithm: string }[] = [
-  { ext: 'md5', algorithm: 'md5' },
-  { ext: 'sha1', algorithm: 'sha-1' },
-  { ext: 'sha256', algorithm: 'sha-256' },
-  { ext: 'sha512', algorithm: 'sha-512' },
+// label suffix (the label key emitted is `hash:<algorithm>`) and the pattern a
+// valid digest of that algorithm must match: exactly N lowercase hex chars.
+// The patterns are compiled once here, not per file. They carry no global/
+// sticky flag, so they hold no mutable `lastIndex` state and a single shared
+// instance is safe to reuse across the concurrent reads below.
+const M2_COMPANION_FILES: {
+  ext: string;
+  algorithm: string;
+  digestPattern: RegExp;
+}[] = [
+  { ext: 'md5', algorithm: 'md5', digestPattern: /^[0-9a-f]{32}$/ },
+  { ext: 'sha1', algorithm: 'sha-1', digestPattern: /^[0-9a-f]{40}$/ },
+  { ext: 'sha256', algorithm: 'sha-256', digestPattern: /^[0-9a-f]{64}$/ },
+  { ext: 'sha512', algorithm: 'sha-512', digestPattern: /^[0-9a-f]{128}$/ },
 ];
 
 // Number of artifacts whose companion files are read concurrently. Matches the
@@ -32,13 +41,19 @@ const CONCURRENCY = 5;
 
 /**
  * Read a single companion-file value. Returns undefined if the file does not
- * exist (older artifacts may not publish SHA-256/SHA-512). Returns the raw
- * hex digest, lowercased — Maven companion files contain the digest as ASCII
- * hex, sometimes followed by a space and the filename; we keep only the digest.
+ * exist (older artifacts may not publish every algorithm), is unreadable, or
+ * does not contain a valid digest. Returns the validated hex digest, lowercased.
+ *
+ * Maven companion files contain the digest as ASCII hex, sometimes followed by a
+ * space and the filename; we keep only the first whitespace-delimited token. The
+ * token is rejected unless it matches `digestPattern` (the algorithm's exact
+ * lowercase-hex shape) — a misconfigured mirror can store an HTML error page or
+ * truncated body in a companion file, and we must not surface that as a hash.
  */
 async function readCompanionFile(
   artifactPath: string,
   ext: string,
+  digestPattern: RegExp,
 ): Promise<string | undefined> {
   const companionPath = `${artifactPath}.${ext}`;
   let raw: string;
@@ -49,10 +64,15 @@ async function readCompanionFile(
     // is unreadable — treat both as "no recorded hash for this algorithm".
     return undefined;
   }
-  // Maven sometimes formats as `<hex>  <filename>`; the first whitespace-delimited
-  // token is the digest. Normalise to lowercase for a stable label value.
-  const digest = raw.split(/\s+/, 1)[0];
-  return digest.toLowerCase();
+  const digest = raw.split(/\s+/, 1)[0].toLowerCase();
+  if (!digestPattern.test(digest)) {
+    debug(
+      `Ignoring ${ext} companion file ${companionPath}: ` +
+        `contents are not a valid digest`,
+    );
+    return undefined;
+  }
+  return digest;
 }
 
 /**
@@ -71,7 +91,9 @@ export async function readM2HashLabels(
   const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
 
   const digests = await Promise.all(
-    M2_COMPANION_FILES.map(({ ext }) => readCompanionFile(artifactPath, ext)),
+    M2_COMPANION_FILES.map(({ ext, digestPattern }) =>
+      readCompanionFile(artifactPath, ext, digestPattern),
+    ),
   );
 
   M2_COMPANION_FILES.forEach(({ algorithm }, i) => {

--- a/lib/parse/scanned-project-builder.ts
+++ b/lib/parse/scanned-project-builder.ts
@@ -10,6 +10,7 @@ export function buildScannedProjects(
   fingerprintMap = new Map<string, FingerprintData>(),
   includePurl = false,
   showMavenBuildScope = false,
+  hashLabelsMap = new Map<string, Record<string, string>>(),
 ): { scannedProjects: ScannedProject[] } {
   const context: ParseContext = {
     includeTestScope,
@@ -17,6 +18,7 @@ export function buildScannedProjects(
     fingerprintMap,
     includePurl,
     showMavenBuildScope,
+    hashLabelsMap,
   };
 
   const scannedProjects: ScannedProject[] = [];

--- a/lib/parse/types.ts
+++ b/lib/parse/types.ts
@@ -92,4 +92,9 @@ export interface ParseContext {
   fingerprintMap: Map<string, FingerprintData>;
   includePurl: boolean;
   showMavenBuildScope?: boolean;
+  // Per-node hash labels read from the local Maven repository's companion
+  // checksum files (e.g. `<artifact>.jar.sha1`). Each entry is keyed by Maven
+  // node ID and contains zero or more `hash:<algorithm>` -> hex digest pairs.
+  // See lib/parse/m2-hash-labels.ts.
+  hashLabelsMap?: Map<string, Record<string, string>>;
 }

--- a/tests/jest/functional/m2-hash-labels.spec.ts
+++ b/tests/jest/functional/m2-hash-labels.spec.ts
@@ -1,0 +1,220 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { parseDigraphs } from '../../../lib/parse/digraph';
+import { buildDepGraph } from '../../../lib/parse/dep-graph';
+import {
+  buildM2HashLabelsMap,
+  readM2HashLabels,
+} from '../../../lib/parse/m2-hash-labels';
+import type { ParseContext } from '../../../lib/parse/types';
+
+// Helper: write a fake artifact JAR plus the three companion files Maven
+// would have written when it pulled the artifact from a registry. The JAR
+// content is arbitrary (we never read it); the companion files contain real
+// hashes of that content so they look like what JFrog/Central would serve.
+function writeFakeArtifact(
+  repoRoot: string,
+  groupId: string,
+  artifactId: string,
+  version: string,
+  payload: Buffer,
+): void {
+  const groupPath = groupId.replace(/\./g, path.sep);
+  const dir = path.join(repoRoot, groupPath, artifactId, version);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const jarPath = path.join(dir, `${artifactId}-${version}.jar`);
+  fs.writeFileSync(jarPath, payload);
+
+  for (const algo of ['md5', 'sha1', 'sha256']) {
+    const digest = crypto.createHash(algo).update(payload).digest('hex');
+    // Maven's published companion files often have the form `<digest>  <filename>`
+    // (two spaces). Mirror that to make sure our parser handles it.
+    fs.writeFileSync(`${jarPath}.${algo}`, `${digest}  ${artifactId}-${version}.jar\n`);
+  }
+}
+
+describe('Maven hash:<alg> label emission from .m2 companion files', () => {
+  let repoRoot: string;
+  let acceptedHashes: Record<string, Record<string, string>>;
+
+  beforeAll(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'snyk-mvn-poc-'));
+
+    // Two artifacts standing in for a small Maven dependency tree.
+    const guavaPayload = Buffer.from('fake guava jar contents');
+    const failureaccessPayload = Buffer.from('fake failureaccess jar contents');
+
+    writeFakeArtifact(
+      repoRoot,
+      'com.google.guava',
+      'guava',
+      '32.1.3-jre',
+      guavaPayload,
+    );
+    writeFakeArtifact(
+      repoRoot,
+      'com.google.guava',
+      'failureaccess',
+      '1.0.1',
+      failureaccessPayload,
+    );
+
+    // Pre-compute the expected hex values so each test can assert exactly.
+    const hashOf = (payload: Buffer, algo: string): string =>
+      crypto.createHash(algo).update(payload).digest('hex');
+
+    acceptedHashes = {
+      'com.google.guava:guava:jar:32.1.3-jre': {
+        'hash:md5': hashOf(guavaPayload, 'md5'),
+        'hash:sha-1': hashOf(guavaPayload, 'sha1'),
+        'hash:sha-256': hashOf(guavaPayload, 'sha256'),
+      },
+      'com.google.guava:failureaccess:jar:1.0.1': {
+        'hash:md5': hashOf(failureaccessPayload, 'md5'),
+        'hash:sha-1': hashOf(failureaccessPayload, 'sha1'),
+        'hash:sha-256': hashOf(failureaccessPayload, 'sha256'),
+      },
+    };
+  });
+
+  afterAll(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  describe('readM2HashLabels', () => {
+    it('reads md5/sha-1/sha-256 from companion files', () => {
+      const labels = readM2HashLabels(
+        'com.google.guava:guava:jar:32.1.3-jre',
+        repoRoot,
+      );
+      expect(labels).toEqual(
+        acceptedHashes['com.google.guava:guava:jar:32.1.3-jre'],
+      );
+    });
+
+    it('returns an empty object when the artifact is not in the repository', () => {
+      const labels = readM2HashLabels(
+        'org.unknown:nothing-here:jar:0.0.0',
+        repoRoot,
+      );
+      expect(labels).toEqual({});
+    });
+
+    it('omits algorithms whose companion file is missing', () => {
+      // Drop the .sha256 to simulate an older artifact without SHA-256
+      // published. The other two should still come back.
+      const jarPath = path.join(
+        repoRoot,
+        'com/google/guava/guava/32.1.3-jre/guava-32.1.3-jre.jar',
+      );
+      const sha256Path = `${jarPath}.sha256`;
+      const sha256Backup = fs.readFileSync(sha256Path);
+      fs.unlinkSync(sha256Path);
+      try {
+        const labels = readM2HashLabels(
+          'com.google.guava:guava:jar:32.1.3-jre',
+          repoRoot,
+        );
+        expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
+      } finally {
+        fs.writeFileSync(sha256Path, sha256Backup);
+      }
+    });
+  });
+
+  describe('buildDepGraph integration', () => {
+    it('emits hash labels on every node with a known artifact', async () => {
+      const diGraph = `"com.google.guava:guava:jar:32.1.3-jre" {
+        "com.google.guava:guava:jar:32.1.3-jre" -> "com.google.guava:failureaccess:jar:1.0.1" ;
+      }`;
+      const mavenGraph = parseDigraphs([diGraph])[0];
+
+      const hashLabelsMap = buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const context: ParseContext = {
+        includeTestScope: false,
+        verboseEnabled: false,
+        fingerprintMap: new Map(),
+        includePurl: false,
+        hashLabelsMap,
+      };
+
+      const depGraph = buildDepGraph(mavenGraph, context);
+      const graphJson = depGraph.toJSON();
+
+      // In this hand-rolled fixture, guava is the root of the dep tree (which
+      // a real Maven project wouldn't have — but we set it up this way to keep
+      // the test compact, and we did seed the .m2 fixture with guava's hashes,
+      // so the root node should carry them).
+      const rootNode = graphJson.graph.nodes.find(
+        (n) => n.nodeId === 'root-node',
+      );
+      expect(rootNode?.info?.labels).toEqual(
+        acceptedHashes['com.google.guava:guava:jar:32.1.3-jre'],
+      );
+
+      // The transitive node — failureaccess — should also carry its hashes.
+      const failureaccess = graphJson.graph.nodes.find(
+        (n) => n.pkgId === 'com.google.guava:failureaccess@1.0.1',
+      );
+      expect(failureaccess).toBeDefined();
+      expect(failureaccess?.info?.labels).toEqual(
+        acceptedHashes['com.google.guava:failureaccess:jar:1.0.1'],
+      );
+    });
+
+    it('emits no hash labels when artifacts are not in the repository', async () => {
+      const diGraph = `"org.unknown:nothing-here:jar:0.0.0" {
+        "org.unknown:nothing-here:jar:0.0.0" -> "org.also-unknown:still-nothing:jar:0.0.0" ;
+      }`;
+      const mavenGraph = parseDigraphs([diGraph])[0];
+
+      const hashLabelsMap = buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const context: ParseContext = {
+        includeTestScope: false,
+        verboseEnabled: false,
+        fingerprintMap: new Map(),
+        includePurl: false,
+        hashLabelsMap,
+      };
+
+      const depGraph = buildDepGraph(mavenGraph, context);
+      const graphJson = depGraph.toJSON();
+
+      for (const node of graphJson.graph.nodes) {
+        const labels = node.info?.labels ?? {};
+        for (const key of Object.keys(labels)) {
+          expect(key.startsWith('hash:')).toBe(false);
+        }
+      }
+    });
+  });
+
+  describe('PoC demo: depgraph with hashes', () => {
+    it('logs the full depgraph JSON for visual inspection', async () => {
+      const diGraph = `"com.google.guava:guava:jar:32.1.3-jre" {
+        "com.google.guava:guava:jar:32.1.3-jre" -> "com.google.guava:failureaccess:jar:1.0.1" ;
+      }`;
+      const mavenGraph = parseDigraphs([diGraph])[0];
+
+      const hashLabelsMap = buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const context: ParseContext = {
+        includeTestScope: false,
+        verboseEnabled: false,
+        fingerprintMap: new Map(),
+        includePurl: false,
+        hashLabelsMap,
+      };
+
+      const depGraph = buildDepGraph(mavenGraph, context);
+      // eslint-disable-next-line no-console
+      console.log(
+        '\n===== Maven depgraph with hash labels =====\n' +
+          JSON.stringify(depGraph.toJSON(), null, 2),
+      );
+    });
+  });
+});

--- a/tests/jest/functional/m2-hash-labels.spec.ts
+++ b/tests/jest/functional/m2-hash-labels.spec.ts
@@ -192,29 +192,4 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       }
     });
   });
-
-  describe('PoC demo: depgraph with hashes', () => {
-    it('logs the full depgraph JSON for visual inspection', async () => {
-      const diGraph = `"com.google.guava:guava:jar:32.1.3-jre" {
-        "com.google.guava:guava:jar:32.1.3-jre" -> "com.google.guava:failureaccess:jar:1.0.1" ;
-      }`;
-      const mavenGraph = parseDigraphs([diGraph])[0];
-
-      const hashLabelsMap = await buildM2HashLabelsMap([mavenGraph], repoRoot);
-      const context: ParseContext = {
-        includeTestScope: false,
-        verboseEnabled: false,
-        fingerprintMap: new Map(),
-        includePurl: false,
-        hashLabelsMap,
-      };
-
-      const depGraph = buildDepGraph(mavenGraph, context);
-      // eslint-disable-next-line no-console
-      console.log(
-        '\n===== Maven depgraph with hash labels =====\n' +
-          JSON.stringify(depGraph.toJSON(), null, 2),
-      );
-    });
-  });
 });

--- a/tests/jest/functional/m2-hash-labels.spec.ts
+++ b/tests/jest/functional/m2-hash-labels.spec.ts
@@ -21,7 +21,7 @@ function writeFakeArtifact(
   artifactId: string,
   version: string,
   payload: Buffer,
-): void {
+): string {
   const groupPath = groupId.replace(/\./g, path.sep);
   const dir = path.join(repoRoot, groupPath, artifactId, version);
   fs.mkdirSync(dir, { recursive: true });
@@ -33,8 +33,14 @@ function writeFakeArtifact(
     const digest = crypto.createHash(algo).update(payload).digest('hex');
     // Maven's published companion files often have the form `<digest>  <filename>`
     // (two spaces). Mirror that to make sure our parser handles it.
-    fs.writeFileSync(`${jarPath}.${algo}`, `${digest}  ${artifactId}-${version}.jar\n`);
+    fs.writeFileSync(
+      `${jarPath}.${algo}`,
+      `${digest}  ${artifactId}-${version}.jar\n`,
+    );
   }
+
+  // Return the JAR path so callers can tweak individual companion files.
+  return jarPath;
 }
 
 describe('Maven hash:<alg> label emission from .m2 companion files', () => {
@@ -105,24 +111,64 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
     });
 
     it('omits algorithms whose companion file is missing', async () => {
-      // Drop the .sha256 to simulate an older artifact without SHA-256
-      // published. The other two should still come back.
-      const jarPath = path.join(
+      // A dedicated artifact missing its .sha256, simulating an older artifact
+      // that never published SHA-256. The other two should still come back.
+      const jarPath = writeFakeArtifact(
         repoRoot,
-        'com/google/guava/guava/32.1.3-jre/guava-32.1.3-jre.jar',
+        'com.example',
+        'no-sha256',
+        '1.0.0',
+        Buffer.from('no-sha256 payload'),
       );
-      const sha256Path = `${jarPath}.sha256`;
-      const sha256Backup = fs.readFileSync(sha256Path);
-      fs.unlinkSync(sha256Path);
-      try {
-        const labels = await readM2HashLabels(
-          'com.google.guava:guava:jar:32.1.3-jre',
-          repoRoot,
-        );
-        expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
-      } finally {
-        fs.writeFileSync(sha256Path, sha256Backup);
-      }
+      fs.unlinkSync(`${jarPath}.sha256`);
+
+      const labels = await readM2HashLabels(
+        'com.example:no-sha256:jar:1.0.0',
+        repoRoot,
+      );
+      expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
+    });
+
+    it('ignores a companion file whose contents are not a valid digest', async () => {
+      // A misconfigured mirror that stored an HTML error page (or any non-digest
+      // body) in the .sha256 companion. It must be dropped, not surfaced as a
+      // bogus hash, while the valid algorithms still come back.
+      const jarPath = writeFakeArtifact(
+        repoRoot,
+        'com.example',
+        'html-sha256',
+        '1.0.0',
+        Buffer.from('html-sha256 payload'),
+      );
+      fs.writeFileSync(
+        `${jarPath}.sha256`,
+        '<!DOCTYPE html><html><body>404 Not Found</body></html>\n',
+      );
+
+      const labels = await readM2HashLabels(
+        'com.example:html-sha256:jar:1.0.0',
+        repoRoot,
+      );
+      expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
+      expect(labels['hash:sha-256']).toBeUndefined();
+    });
+
+    it('rejects a digest of the wrong length for its algorithm', async () => {
+      // A truncated/short hex string must not be accepted as a sha-256.
+      const jarPath = writeFakeArtifact(
+        repoRoot,
+        'com.example',
+        'short-sha256',
+        '1.0.0',
+        Buffer.from('short-sha256 payload'),
+      );
+      fs.writeFileSync(`${jarPath}.sha256`, 'deadbeef\n');
+
+      const labels = await readM2HashLabels(
+        'com.example:short-sha256:jar:1.0.0',
+        repoRoot,
+      );
+      expect(labels['hash:sha-256']).toBeUndefined();
     });
   });
 

--- a/tests/jest/functional/m2-hash-labels.spec.ts
+++ b/tests/jest/functional/m2-hash-labels.spec.ts
@@ -86,8 +86,8 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
   });
 
   describe('readM2HashLabels', () => {
-    it('reads md5/sha-1/sha-256 from companion files', () => {
-      const labels = readM2HashLabels(
+    it('reads md5/sha-1/sha-256 from companion files', async () => {
+      const labels = await readM2HashLabels(
         'com.google.guava:guava:jar:32.1.3-jre',
         repoRoot,
       );
@@ -96,15 +96,15 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       );
     });
 
-    it('returns an empty object when the artifact is not in the repository', () => {
-      const labels = readM2HashLabels(
+    it('returns an empty object when the artifact is not in the repository', async () => {
+      const labels = await readM2HashLabels(
         'org.unknown:nothing-here:jar:0.0.0',
         repoRoot,
       );
       expect(labels).toEqual({});
     });
 
-    it('omits algorithms whose companion file is missing', () => {
+    it('omits algorithms whose companion file is missing', async () => {
       // Drop the .sha256 to simulate an older artifact without SHA-256
       // published. The other two should still come back.
       const jarPath = path.join(
@@ -115,7 +115,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       const sha256Backup = fs.readFileSync(sha256Path);
       fs.unlinkSync(sha256Path);
       try {
-        const labels = readM2HashLabels(
+        const labels = await readM2HashLabels(
           'com.google.guava:guava:jar:32.1.3-jre',
           repoRoot,
         );
@@ -133,7 +133,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       }`;
       const mavenGraph = parseDigraphs([diGraph])[0];
 
-      const hashLabelsMap = buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const hashLabelsMap = await buildM2HashLabelsMap([mavenGraph], repoRoot);
       const context: ParseContext = {
         includeTestScope: false,
         verboseEnabled: false,
@@ -172,7 +172,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       }`;
       const mavenGraph = parseDigraphs([diGraph])[0];
 
-      const hashLabelsMap = buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const hashLabelsMap = await buildM2HashLabelsMap([mavenGraph], repoRoot);
       const context: ParseContext = {
         includeTestScope: false,
         verboseEnabled: false,
@@ -200,7 +200,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       }`;
       const mavenGraph = parseDigraphs([diGraph])[0];
 
-      const hashLabelsMap = buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const hashLabelsMap = await buildM2HashLabelsMap([mavenGraph], repoRoot);
       const context: ParseContext = {
         includeTestScope: false,
         verboseEnabled: false,

--- a/tests/jest/system/m2-hash-labels-e2e.spec.ts
+++ b/tests/jest/system/m2-hash-labels-e2e.spec.ts
@@ -1,0 +1,116 @@
+import { inspect } from '../../../lib/index';
+import { legacyPlugin } from '@snyk/cli-interface';
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+const testsPath = path.join(__dirname, '../..');
+const fixturesPath = path.join(testsPath, 'fixtures');
+const testProjectPath = path.join(fixturesPath, 'test-project');
+
+// Hash labels are read from the JAR's companion checksum files in the local
+// Maven repository. A bare `dependency:tree` resolution does not necessarily
+// download the JAR bytes (and therefore the `.jar.sha1`/`.md5` companions), so
+// resolve the fixture's artifacts into `~/.m2` up front — CI starts with an
+// empty repository.
+beforeAll(() => {
+  execFileSync('mvn', ['clean', 'install', '-DskipTests'], {
+    cwd: testProjectPath,
+    stdio: 'ignore',
+  });
+}, 300000);
+
+function hashLabelKeys(labels?: {
+  [key: string]: string | undefined;
+}): string[] {
+  return Object.keys(labels ?? {}).filter((key) => key.startsWith('hash:'));
+}
+
+test('hash labels disabled vs enabled comparison', async () => {
+  // Hashes disabled (default).
+  const resultDisabled = await inspect(
+    '.',
+    path.join(testProjectPath, 'pom.xml'),
+    {
+      dev: false,
+      includeHashes: false,
+    },
+  );
+
+  if (!legacyPlugin.isMultiResult(resultDisabled)) {
+    throw new Error('expected multi inspect result for disabled case');
+  }
+
+  // Hashes enabled.
+  const resultEnabled = await inspect(
+    '.',
+    path.join(testProjectPath, 'pom.xml'),
+    {
+      dev: false,
+      includeHashes: true,
+    },
+  );
+
+  if (!legacyPlugin.isMultiResult(resultEnabled)) {
+    throw new Error('expected multi inspect result for enabled case');
+  }
+
+  const disabledGraph = resultDisabled.scannedProjects[0].depGraph!.toJSON();
+  const enabledGraph = resultEnabled.scannedProjects[0].depGraph!.toJSON();
+
+  // The flag only adds labels; the graph shape is unchanged.
+  expect(enabledGraph.graph.nodes.length).toBe(
+    disabledGraph.graph.nodes.length,
+  );
+
+  // Disabled: no node carries a hash:* label.
+  for (const node of disabledGraph.graph.nodes) {
+    expect(hashLabelKeys(node.info?.labels)).toHaveLength(0);
+  }
+
+  // Enabled: the axis dependency was resolved into the local Maven repository,
+  // so it carries the `.jar.sha1` companion hash. Even though Maven Central
+  // publishes several checksum files per artifact, Maven only downloads a
+  // single one to verify the JAR, so .sha1 is the one companion reliably
+  // present locally; assert the others' format only when they happen to exist.
+  const axisNode = enabledGraph.graph.nodes.find(
+    (node) => node.pkgId === 'axis:axis@1.4',
+  );
+  expect(axisNode).toBeDefined();
+
+  const axisLabels = axisNode?.info?.labels ?? {};
+  expect(axisLabels['hash:sha-1']).toMatch(/^[0-9a-f]{40}$/);
+  if (axisLabels['hash:md5']) {
+    expect(axisLabels['hash:md5']).toMatch(/^[0-9a-f]{32}$/);
+  }
+  if (axisLabels['hash:sha-256']) {
+    expect(axisLabels['hash:sha-256']).toMatch(/^[0-9a-f]{64}$/);
+  }
+  if (axisLabels['hash:sha-512']) {
+    expect(axisLabels['hash:sha-512']).toMatch(/^[0-9a-f]{128}$/);
+  }
+
+  // At least one resolved dependency carries hash labels end-to-end.
+  const nodesWithHashes = enabledGraph.graph.nodes.filter(
+    (node) => hashLabelKeys(node.info?.labels).length > 0,
+  );
+  expect(nodesWithHashes.length).toBeGreaterThan(0);
+});
+
+test('hash labels graceful failure with nonexistent repository', async () => {
+  // Point the hash reader at a repository that does not exist. Maven still
+  // resolves the tree, but no companion files can be read, so inspect succeeds
+  // with no hash labels rather than throwing.
+  const result = await inspect('.', path.join(testProjectPath, 'pom.xml'), {
+    dev: false,
+    includeHashes: true,
+    mavenRepository: '/completely/nonexistent/path',
+  });
+
+  if (!legacyPlugin.isMultiResult(result)) {
+    throw new Error('expected multi inspect result');
+  }
+
+  for (const node of result.scannedProjects[0].depGraph!.toJSON().graph.nodes) {
+    expect(hashLabelKeys(node.info?.labels)).toHaveLength(0);
+  }
+});

--- a/tests/jest/system/m2-hash-labels-e2e.spec.ts
+++ b/tests/jest/system/m2-hash-labels-e2e.spec.ts
@@ -1,11 +1,16 @@
 import { inspect } from '../../../lib/index';
 import { legacyPlugin } from '@snyk/cli-interface';
 import { execFileSync } from 'child_process';
+import * as os from 'os';
 import * as path from 'path';
 
 const testsPath = path.join(__dirname, '../..');
 const fixturesPath = path.join(testsPath, 'fixtures');
 const testProjectPath = path.join(fixturesPath, 'test-project');
+
+// On Windows the executable is `mvn.cmd`, which Node only resolves when spawned
+// through a shell — mirror lib/sub-process.ts, which sets `shell: true` there.
+const isWindows = /^win/.test(os.platform());
 
 // Hash labels are read from the JAR's companion checksum files in the local
 // Maven repository. A bare `dependency:tree` resolution does not necessarily
@@ -16,6 +21,7 @@ beforeAll(() => {
   execFileSync('mvn', ['clean', 'install', '-DskipTests'], {
     cwd: testProjectPath,
     stdio: 'ignore',
+    shell: isWindows,
   });
 }, 300000);
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This adds support for retrieving the checksum data for artifacts used by maven builds, and reporting them as labels attached to nodes in the resulting DepGraph like so:
```
      {
        "nodeId": "org.jboss.logging:jboss-logging:jar:3.5.3.Final:compile",
        "pkgId": "org.jboss.logging:jboss-logging@3.5.3.Final",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "c88fc1d8a96d4c3491f55d4317458ccad53ca663"
          }
        }
      },
```

#### How should this be manually tested?

This can be naively tested by hooking the changed `snyk-mvn-plugin` into the `cli` and wiring in a new flag that will pass the `includeHashes` flag to the plugin, building the legacy cli then invoking `snyk test --include-hashes --print-graph` or similar. That is quite onerous, so to illustrate the output:
```
❯ ~/code/cli/bin/snyk test --print-graph --include-hashes | head -2 | tail -1 | jq '.'
{
  "schemaVersion": "1.3.0",
  "pkgManager": {
    "name": "maven"
  },
  "pkgs": [
    {
      "id": "io.snyk.os-managed:bad-resolution@1.0.0",
      "info": {
        "name": "io.snyk.os-managed:bad-resolution",
        "version": "1.0.0"
      }
    },
    {
      "id": "org.jboss.resteasy:resteasy-core@6.2.12.Final",
      "info": {
        "name": "org.jboss.resteasy:resteasy-core",
        "version": "6.2.12.Final"
      }
    },
    {
      "id": "com.ibm.async:asyncutil@0.1.0",
      "info": {
        "name": "com.ibm.async:asyncutil",
        "version": "0.1.0"
      }
    },
    {
      "id": "jakarta.validation:jakarta.validation-api@3.0.2",
      "info": {
        "name": "jakarta.validation:jakarta.validation-api",
        "version": "3.0.2"
      }
    },
    {
      "id": "org.eclipse.angus:angus-activation@2.0.2",
      "info": {
        "name": "org.eclipse.angus:angus-activation",
        "version": "2.0.2"
      }
    },
    {
      "id": "jakarta.activation:jakarta.activation-api@2.1.3",
      "info": {
        "name": "jakarta.activation:jakarta.activation-api",
        "version": "2.1.3"
      }
    },
    {
      "id": "org.reactivestreams:reactive-streams@1.0.4",
      "info": {
        "name": "org.reactivestreams:reactive-streams",
        "version": "1.0.4"
      }
    },
    {
      "id": "org.jboss.resteasy:resteasy-core-spi@6.2.12.Final",
      "info": {
        "name": "org.jboss.resteasy:resteasy-core-spi",
        "version": "6.2.12.Final"
      }
    },
    {
      "id": "jakarta.xml.bind:jakarta.xml.bind-api@3.0.1",
      "info": {
        "name": "jakarta.xml.bind:jakarta.xml.bind-api",
        "version": "3.0.1"
      }
    },
    {
      "id": "jakarta.ws.rs:jakarta.ws.rs-api@3.1.0",
      "info": {
        "name": "jakarta.ws.rs:jakarta.ws.rs-api",
        "version": "3.1.0"
      }
    },
    {
      "id": "jakarta.annotation:jakarta.annotation-api@2.1.1",
      "info": {
        "name": "jakarta.annotation:jakarta.annotation-api",
        "version": "2.1.1"
      }
    },
    {
      "id": "org.jboss.logging:jboss-logging@3.5.3.Final",
      "info": {
        "name": "org.jboss.logging:jboss-logging",
        "version": "3.5.3.Final"
      }
    },
    {
      "id": "org.jboss:jandex@2.4.5.Final",
      "info": {
        "name": "org.jboss:jandex",
        "version": "2.4.5.Final"
      }
    }
  ],
  "graph": {
    "rootNodeId": "root-node",
    "nodes": [
      {
        "nodeId": "root-node",
        "pkgId": "io.snyk.os-managed:bad-resolution@1.0.0",
        "deps": [
          {
            "nodeId": "org.jboss.resteasy:resteasy-core:jar:6.2.12.Final:compile"
          }
        ]
      },
      {
        "nodeId": "org.jboss.resteasy:resteasy-core:jar:6.2.12.Final:compile",
        "pkgId": "org.jboss.resteasy:resteasy-core@6.2.12.Final",
        "deps": [
          {
            "nodeId": "com.ibm.async:asyncutil:jar:0.1.0:compile"
          },
          {
            "nodeId": "jakarta.validation:jakarta.validation-api:jar:3.0.2:compile"
          },
          {
            "nodeId": "org.eclipse.angus:angus-activation:jar:2.0.2:compile"
          },
          {
            "nodeId": "jakarta.activation:jakarta.activation-api:jar:2.1.3:compile"
          },
          {
            "nodeId": "org.reactivestreams:reactive-streams:jar:1.0.4:compile"
          },
          {
            "nodeId": "org.jboss.resteasy:resteasy-core-spi:jar:6.2.12.Final:compile"
          },
          {
            "nodeId": "org.jboss:jandex:jar:2.4.5.Final:compile"
          },
          {
            "nodeId": "jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile"
          },
          {
            "nodeId": "jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0:compile"
          },
          {
            "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile"
          },
          {
            "nodeId": "org.jboss.logging:jboss-logging:jar:3.5.3.Final:compile"
          }
        ],
        "info": {
          "labels": {
            "hash:sha-1": "45c4596118651373c5c854c69ef1cfa1feaad3cc"
          }
        }
      },
      {
        "nodeId": "com.ibm.async:asyncutil:jar:0.1.0:compile",
        "pkgId": "com.ibm.async:asyncutil@0.1.0",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "440941c382166029a299602e6c9ff5abde1b5143"
          }
        }
      },
      {
        "nodeId": "jakarta.validation:jakarta.validation-api:jar:3.0.2:compile",
        "pkgId": "jakarta.validation:jakarta.validation-api@3.0.2",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "92b6631659ba35ca09e44874d3eb936edfeee532"
          }
        }
      },
      {
        "nodeId": "org.eclipse.angus:angus-activation:jar:2.0.2:compile",
        "pkgId": "org.eclipse.angus:angus-activation@2.0.2",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "41f1e0ddd157c856926ed149ab837d110955a9fc"
          }
        }
      },
      {
        "nodeId": "jakarta.activation:jakarta.activation-api:jar:2.1.3:compile",
        "pkgId": "jakarta.activation:jakarta.activation-api@2.1.3",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "fa165bd70cda600368eee31555222776a46b881f"
          }
        }
      },
      {
        "nodeId": "org.reactivestreams:reactive-streams:jar:1.0.4:compile",
        "pkgId": "org.reactivestreams:reactive-streams@1.0.4",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "3864a1320d97d7b045f729a326e1e077661f31b7"
          }
        }
      },
      {
        "nodeId": "org.jboss.resteasy:resteasy-core-spi:jar:6.2.12.Final:compile",
        "pkgId": "org.jboss.resteasy:resteasy-core-spi@6.2.12.Final",
        "deps": [
          {
            "nodeId": "jakarta.validation:jakarta.validation-api:jar:3.0.2:compile"
          },
          {
            "nodeId": "org.reactivestreams:reactive-streams:jar:1.0.4:compile"
          },
          {
            "nodeId": "jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile"
          },
          {
            "nodeId": "jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0:compile"
          },
          {
            "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile"
          },
          {
            "nodeId": "org.jboss.logging:jboss-logging:jar:3.5.3.Final:compile"
          }
        ],
        "info": {
          "labels": {
            "hash:sha-1": "dfdce6a2fa042c07975c8d4fa11d259ca883878a"
          }
        }
      },
      {
        "nodeId": "jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile",
        "pkgId": "jakarta.xml.bind:jakarta.xml.bind-api@3.0.1",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "5257932df36ff3e4e6de50429dde946490a6a800"
          }
        }
      },
      {
        "nodeId": "jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0:compile",
        "pkgId": "jakarta.ws.rs:jakarta.ws.rs-api@3.1.0",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "15ce10d249a38865b58fc39521f10f29ab0e3363"
          }
        }
      },
      {
        "nodeId": "jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile",
        "pkgId": "jakarta.annotation:jakarta.annotation-api@2.1.1",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "48b9bda22b091b1f48b13af03fe36db3be6e1ae3"
          }
        }
      },
      {
        "nodeId": "org.jboss.logging:jboss-logging:jar:3.5.3.Final:compile",
        "pkgId": "org.jboss.logging:jboss-logging@3.5.3.Final",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "c88fc1d8a96d4c3491f55d4317458ccad53ca663"
          }
        }
      },
      {
        "nodeId": "org.jboss:jandex:jar:2.4.5.Final:compile",
        "pkgId": "org.jboss:jandex@2.4.5.Final",
        "deps": [],
        "info": {
          "labels": {
            "hash:sha-1": "9b4634d1fa28628549eb986b7c0c73f387090fba"
          }
        }
      }
    ]
  }
}
```

#### Any background context you want to provide?

The local maven repository includes various companion files to the downloaded artifacts that contain checksums. e.g.:
```
❯ ls ~/.m2/repository/org/jboss/resteasy/resteasy-core/6.2.12.Final
_remote.repositories                resteasy-core-6.2.12.Final.pom
resteasy-core-6.2.12.Final.jar      resteasy-core-6.2.12.Final.pom.sha1
resteasy-core-6.2.12.Final.jar.sha1
```

These contain the specified hash of the file as stored on the remote repository.

#### What are the relevant tickets?
- [CMPA-604](https://snyksec.atlassian.net/browse/CMPA-604)


[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ