### PR TITLE
fix: Use npm OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,9 @@ jobs:
       - install_deps
       - run:
           name: Publish to GitHub
-          command: npx semantic-release
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release
 
 workflows:
   version: 2
@@ -404,7 +406,9 @@ workflows:
       # Release
       - release:
           name: Release
-          context: nodejs-app-release
+          context:
+            - nodejs-install
+            - github-release
           requires:
             - test-osx
             - test-windows

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 package-lock=false
+min-release-age=4
+

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/snyk/snyk-mvn-plugin"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/index.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This swaps the pipeline to use OIDC Trusted Publishing

#### Related tickets

- [CMPA-552](https://snyksec.atlassian.net/browse/CMPA-552)


[CMPA-552]: https://snyksec.atlassian.net/browse/CMPA-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ