### PR TITLE
fix: Renames includeHashes -> includeComponentMetadata

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,7 +45,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   mavenAggregateProject?: boolean;
   mavenVerboseIncludeAllVersions?: boolean;
   includeProvenance?: boolean;
-  includeHashes?: boolean;
+  includeComponentMetadata?: boolean;
   fingerprintAlgorithm?: HashAlgorithm;
   mavenRepository?: string;
   showMavenBuildScope?: boolean;
@@ -173,9 +173,9 @@ export async function inspect(
 
     // Read install-time-recorded companion-file hashes (e.g. `.jar.sha1`) from
     // the local Maven repository and surface them as `hash:<algorithm>` labels.
-    // Gated behind its own `--include-hashes` option for now.
+    // Gated behind its own `--include-component-metadata` option for now.
     let hashLabelsMap = new Map<string, Record<string, string>>();
-    if (options.includeHashes) {
+    if (options.includeComponentMetadata) {
       const repositoryPath = await getMavenRepositoryPath(
         mavenContext.command,
         options.mavenRepository,

--- a/tests/jest/system/m2-hash-labels-e2e.spec.ts
+++ b/tests/jest/system/m2-hash-labels-e2e.spec.ts
@@ -38,7 +38,7 @@ test('hash labels disabled vs enabled comparison', async () => {
     path.join(testProjectPath, 'pom.xml'),
     {
       dev: false,
-      includeHashes: false,
+      includeComponentMetadata: false,
     },
   );
 
@@ -52,7 +52,7 @@ test('hash labels disabled vs enabled comparison', async () => {
     path.join(testProjectPath, 'pom.xml'),
     {
       dev: false,
-      includeHashes: true,
+      includeComponentMetadata: true,
     },
   );
 
@@ -108,7 +108,7 @@ test('hash labels graceful failure with nonexistent repository', async () => {
   // with no hash labels rather than throwing.
   const result = await inspect('.', path.join(testProjectPath, 'pom.xml'), {
     dev: false,
-    includeHashes: true,
+    includeComponentMetadata: true,
     mavenRepository: '/completely/nonexistent/path',
   });
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Renames not yet released argument `includeHashes` -> `includeComponentMetadata`

#### What are the relevant tickets?
- [CMPA-604](https://snyksec.atlassian.net/browse/CMPA-604)

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ