### PR TITLE
fix: Bump semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-config-prettier": "^8.5.0",
     "jest": "^29.7.0",
     "prettier": "^2.7.1",
-    "semantic-release": "^15",
+    "semantic-release": "^25.0.3",
     "sinon": "^2.4.1",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps the version of `semantic-release` used to `^25.0.3`