### PR TITLE
feat: [CMPA-604] Add `distribution:url` label to nodes on DepGraph when `includeComponentMetadata`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,11 +18,12 @@ import {
   generateMavenFingerprints,
   getMavenRepositoryPath,
 } from './fingerprint';
-import { buildM2HashLabelsMap } from './parse/m2-hash-labels';
+import { readM2HashLabels } from './parse/m2-hash-labels';
 import {
   fetchRepositoryUrlMap,
-  buildRemoteRepositoriesMap,
+  readRemoteRepositoryLabel,
 } from './parse/m2-remote-repositories';
+import { collectM2Nodes, buildLabelMap } from './parse/m2-batch';
 import {
   SnykHttpClient,
   HashAlgorithm,
@@ -192,19 +193,28 @@ export async function inspect(
     }
 
     if (options.includeComponentMetadata && repositoryPath) {
-      hashLabelsMap = await buildM2HashLabelsMap(mavenGraphs, repositoryPath);
-    }
+      // Resolve the node set and artifact paths once; both label passes reuse it.
+      const m2Nodes = collectM2Nodes(mavenGraphs, repositoryPath);
 
-    if (options.includeComponentMetadata && repositoryPath) {
+      // The hash-label reads only touch the local repository, so kick them off
+      // concurrently with the dependency:list-repositories subprocess instead
+      // of waiting for it.
+      const hashLabelsPromise = buildLabelMap(m2Nodes, (node) =>
+        readM2HashLabels(node.artifactPath),
+      );
+
       const repoUrlMap = await fetchRepositoryUrlMap(
         mavenContext,
         !!options.mavenAggregateProject,
       );
-      remoteRepositoriesMap = await buildRemoteRepositoriesMap(
-        mavenGraphs,
-        repositoryPath,
-        repoUrlMap,
+      const remoteRepositoriesPromise = buildLabelMap(m2Nodes, (node) =>
+        readRemoteRepositoryLabel(node, repositoryPath, repoUrlMap),
       );
+
+      [hashLabelsMap, remoteRepositoriesMap] = await Promise.all([
+        hashLabelsPromise,
+        remoteRepositoriesPromise,
+      ]);
     }
 
     // Build scanned projects

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -206,6 +206,7 @@ export async function inspect(
         mavenContext,
         !!options.mavenAggregateProject,
         executionResult.explicitPluginVersion,
+        args,
       );
 
       const hashLabelsPromise = buildLabelMap(m2Nodes, (node) =>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,7 +21,7 @@ import {
 import { readM2HashLabels } from './parse/m2-hash-labels';
 import {
   fetchRepositoryUrlMap,
-  readRemoteRepositoryLabel,
+  buildRemoteRepositoryLabelMap,
 } from './parse/m2-remote-repositories';
 import { collectM2Nodes, buildLabelMap } from './parse/m2-batch';
 import {
@@ -196,20 +196,25 @@ export async function inspect(
       // Resolve the node set and artifact paths once; both label passes reuse it.
       const m2Nodes = collectM2Nodes(mavenGraphs, repositoryPath);
 
-      // The hash-label reads only touch the local repository, so kick them off
-      // concurrently with the dependency:list-repositories subprocess instead
-      // of waiting for it.
-      const hashLabelsPromise = buildLabelMap(m2Nodes, (node) =>
-        readM2HashLabels(node.artifactPath),
-      );
-
-      const repoUrlMap = await fetchRepositoryUrlMap(
+      // Both label passes read only local-repository files (hash companions and
+      // _remote.repositories), so run them concurrently with the
+      // dependency:list-repositories subprocess rather than waiting for it: kick
+      // the subprocess off first, then start the reads. The distribution:url
+      // pass reads repo ids up front and only awaits the subprocess result for
+      // the final in-memory URL join (see buildRemoteRepositoryLabelMap).
+      const repoUrlMapPromise = fetchRepositoryUrlMap(
         mavenContext,
         !!options.mavenAggregateProject,
         executionResult.explicitPluginVersion,
       );
-      const remoteRepositoriesPromise = buildLabelMap(m2Nodes, (node) =>
-        readRemoteRepositoryLabel(node, repositoryPath, repoUrlMap),
+
+      const hashLabelsPromise = buildLabelMap(m2Nodes, (node) =>
+        readM2HashLabels(node.artifactPath),
+      );
+      const remoteRepositoriesPromise = buildRemoteRepositoryLabelMap(
+        m2Nodes,
+        repositoryPath,
+        repoUrlMapPromise,
       );
 
       [hashLabelsMap, remoteRepositoriesMap] = await Promise.all([

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -20,6 +20,10 @@ import {
 } from './fingerprint';
 import { buildM2HashLabelsMap } from './parse/m2-hash-labels';
 import {
+  fetchRepositoryUrlMap,
+  buildRemoteRepositoriesMap,
+} from './parse/m2-remote-repositories';
+import {
   SnykHttpClient,
   HashAlgorithm,
   FingerprintOptions,
@@ -50,6 +54,7 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   mavenRepository?: string;
   showMavenBuildScope?: boolean;
   mavenSkipWrapper?: boolean;
+  includeDistribution?: boolean;
 }
 
 function buildFingerprintOptions(
@@ -173,14 +178,31 @@ export async function inspect(
 
     // Read install-time-recorded companion-file hashes (e.g. `.jar.sha1`) from
     // the local Maven repository and surface them as `hash:<algorithm>` labels.
-    // Gated behind its own `--include-component-metadata` option for now.
+    // Also read distribution source info from _remote.repositories files.
+    // Both require access to the local Maven repository, so we hoist that
+    // path resolution here to run once.
+    let repositoryPath: string | undefined;
+    let remoteRepositoriesMap = new Map<string, Record<string, string>>();
     let hashLabelsMap = new Map<string, Record<string, string>>();
+
     if (options.includeComponentMetadata) {
-      const repositoryPath = await getMavenRepositoryPath(
+      repositoryPath = await getMavenRepositoryPath(
         mavenContext.command,
         options.mavenRepository,
       );
+    }
+
+    if (options.includeComponentMetadata && repositoryPath) {
       hashLabelsMap = await buildM2HashLabelsMap(mavenGraphs, repositoryPath);
+    }
+
+    if (options.includeDistribution && repositoryPath) {
+      const repoUrlMap = await fetchRepositoryUrlMap(mavenContext.command);
+      remoteRepositoriesMap = await buildRemoteRepositoriesMap(
+        mavenGraphs,
+        repositoryPath,
+        repoUrlMap,
+      );
     }
 
     // Build scanned projects
@@ -192,6 +214,7 @@ export async function inspect(
       !!fingerprintOptions?.enabled,
       !!options.showMavenBuildScope,
       hashLabelsMap,
+      remoteRepositoriesMap,
     );
 
     return {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -54,7 +54,6 @@ export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
   mavenRepository?: string;
   showMavenBuildScope?: boolean;
   mavenSkipWrapper?: boolean;
-  includeDistribution?: boolean;
 }
 
 function buildFingerprintOptions(
@@ -196,8 +195,11 @@ export async function inspect(
       hashLabelsMap = await buildM2HashLabelsMap(mavenGraphs, repositoryPath);
     }
 
-    if (options.includeDistribution && repositoryPath) {
-      const repoUrlMap = await fetchRepositoryUrlMap(mavenContext.command);
+    if (options.includeComponentMetadata && repositoryPath) {
+      const repoUrlMap = await fetchRepositoryUrlMap(
+        mavenContext,
+        !!options.mavenAggregateProject,
+      );
       remoteRepositoriesMap = await buildRemoteRepositoriesMap(
         mavenGraphs,
         repositoryPath,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -206,6 +206,7 @@ export async function inspect(
       const repoUrlMap = await fetchRepositoryUrlMap(
         mavenContext,
         !!options.mavenAggregateProject,
+        executionResult.explicitPluginVersion,
       );
       const remoteRepositoriesPromise = buildLabelMap(m2Nodes, (node) =>
         readRemoteRepositoryLabel(node, repositoryPath, repoUrlMap),

--- a/lib/maven/executor.ts
+++ b/lib/maven/executor.ts
@@ -29,6 +29,11 @@ export interface MavenExecutionResult {
   javaVersion?: string;
   mavenVersion?: string;
   mavenPluginVersion?: string;
+  // The maven-dependency-plugin version we explicitly pin the pipeline to
+  // (selected from the detected Maven version). Callers that spawn additional
+  // dependency-plugin goals — e.g. list-repositories for distribution:url
+  // labels — pin to this so their output format matches the pipeline's.
+  explicitPluginVersion: string;
   command: string;
   args: string[];
 }
@@ -97,6 +102,7 @@ export async function executeMavenPipeline(
     javaVersion,
     mavenVersion,
     mavenPluginVersion: treeResult.mavenPluginVersion,
+    explicitPluginVersion,
     command: treeResult.command,
     args: treeResult.args,
   };

--- a/lib/parse/dep-graph.ts
+++ b/lib/parse/dep-graph.ts
@@ -161,6 +161,15 @@ function createNodeInfo(
     Object.assign(labels, hashLabels);
   }
 
+  // Merge distribution-source labels (read from `.m2/.../repository/*/_remote.repositories`
+  // and resolved to full artifact URLs via Maven's dependency:list-repositories).
+  // These are consumed downstream to populate CycloneDX `component.ExternalReferences`
+  // with type="distribution".
+  const repoLabels = context.remoteRepositoriesMap?.get(depInfo.id);
+  if (repoLabels) {
+    Object.assign(labels, repoLabels);
+  }
+
   if (Object.keys(labels).length === 0) {
     return;
   }

--- a/lib/parse/m2-batch.ts
+++ b/lib/parse/m2-batch.ts
@@ -39,27 +39,45 @@ export function collectM2Nodes(
 }
 
 /**
- * Run `readLabels` for every node in bounded-concurrency batches and return a
- * Map<nodeId, labels> containing only the nodes that produced a non-empty label
- * set. Reads run asynchronously in bounded batches so they never block the
- * event loop. The shared scaffold for any per-node label-reading pass.
+ * Run `read` for every node in bounded-concurrency batches and return a
+ * Map<nodeId, result> for the nodes whose result `keep` accepts. Reads run
+ * asynchronously in bounded batches so they never block the event loop. The
+ * shared scaffold for any per-node async pass over the local Maven repository —
+ * label sets, recorded repo ids, etc.
  */
-export async function buildLabelMap(
+export async function mapNodes<T>(
   nodes: M2Node[],
-  readLabels: (node: M2Node) => Promise<Record<string, string>>,
-): Promise<Map<string, Record<string, string>>> {
-  const result = new Map<string, Record<string, string>>();
+  read: (node: M2Node) => Promise<T>,
+  keep: (value: T) => boolean,
+): Promise<Map<string, T>> {
+  const result = new Map<string, T>();
 
   for (let i = 0; i < nodes.length; i += CONCURRENCY) {
     const batch = nodes.slice(i, i + CONCURRENCY);
-    const batchResults = await Promise.all(batch.map(readLabels));
+    const batchResults = await Promise.all(batch.map(read));
     batch.forEach((node, j) => {
-      const labels = batchResults[j];
-      if (Object.keys(labels).length > 0) {
-        result.set(node.nodeId, labels);
+      const value = batchResults[j];
+      if (keep(value)) {
+        result.set(node.nodeId, value);
       }
     });
   }
 
   return result;
+}
+
+/**
+ * Run `readLabels` for every node and return a Map<nodeId, labels> containing
+ * only the nodes that produced a non-empty label set. Thin specialisation of
+ * {@link mapNodes} for the per-node label-reading passes (hashes, etc.).
+ */
+export function buildLabelMap(
+  nodes: M2Node[],
+  readLabels: (node: M2Node) => Promise<Record<string, string>>,
+): Promise<Map<string, Record<string, string>>> {
+  return mapNodes(
+    nodes,
+    readLabels,
+    (labels) => Object.keys(labels).length > 0,
+  );
 }

--- a/lib/parse/m2-batch.ts
+++ b/lib/parse/m2-batch.ts
@@ -1,0 +1,65 @@
+import type { MavenGraph } from './types';
+import { dependencyIdToArtifactPath } from '../fingerprint';
+
+/**
+ * Number of artifacts processed per batch. We batch to avoid spawning too many
+ * concurrent file reads. Note a single node may itself fan out into several
+ * reads (e.g. one companion file per hash algorithm), so the in-flight read
+ * count can be a small multiple of this.
+ */
+export const CONCURRENCY = 5;
+
+/**
+ * A Maven graph node paired with the path to its artifact in the local Maven
+ * repository. Resolved once via {@link collectM2Nodes} so the hash-label and
+ * distribution-url passes can share it rather than each recomputing it.
+ */
+export interface M2Node {
+  nodeId: string;
+  artifactPath: string;
+}
+
+/**
+ * Collect the unique node IDs across all graphs and resolve each to its
+ * artifact path in the local Maven repository. Done once so every per-node
+ * pass (hashes, distribution URLs) can reuse the same node set and paths.
+ */
+export function collectM2Nodes(
+  mavenGraphs: MavenGraph[],
+  repositoryPath: string,
+): M2Node[] {
+  const nodeIds = new Set<string>();
+  for (const graph of mavenGraphs) {
+    Object.keys(graph.nodes).forEach((nodeId) => nodeIds.add(nodeId));
+  }
+  return Array.from(nodeIds).map((nodeId) => ({
+    nodeId,
+    artifactPath: dependencyIdToArtifactPath(nodeId, repositoryPath),
+  }));
+}
+
+/**
+ * Run `readLabels` for every node in bounded-concurrency batches and return a
+ * Map<nodeId, labels> containing only the nodes that produced a non-empty label
+ * set. Reads run asynchronously in bounded batches so they never block the
+ * event loop. The shared scaffold for any per-node label-reading pass.
+ */
+export async function buildLabelMap(
+  nodes: M2Node[],
+  readLabels: (node: M2Node) => Promise<Record<string, string>>,
+): Promise<Map<string, Record<string, string>>> {
+  const result = new Map<string, Record<string, string>>();
+
+  for (let i = 0; i < nodes.length; i += CONCURRENCY) {
+    const batch = nodes.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(batch.map(readLabels));
+    batch.forEach((node, j) => {
+      const labels = batchResults[j];
+      if (Object.keys(labels).length > 0) {
+        result.set(node.nodeId, labels);
+      }
+    });
+  }
+
+  return result;
+}

--- a/lib/parse/m2-hash-labels.ts
+++ b/lib/parse/m2-hash-labels.ts
@@ -1,6 +1,4 @@
 import * as fs from 'fs';
-import type { MavenGraph } from './types';
-import { dependencyIdToArtifactPath } from '../fingerprint';
 import { debug } from '../index';
 
 /**
@@ -36,11 +34,6 @@ const M2_COMPANION_FILES: {
   { ext: 'sha256', algorithm: 'sha-256', digestPattern: /^[0-9a-f]{64}$/ },
   { ext: 'sha512', algorithm: 'sha-512', digestPattern: /^[0-9a-f]{128}$/ },
 ];
-
-// Number of artifacts processed per batch. Each artifact reads its companion
-// files concurrently (up to one per entry in M2_COMPANION_FILES), so up to
-// CONCURRENCY * M2_COMPANION_FILES.length companion reads are in flight at once.
-const CONCURRENCY = 5;
 
 // Upper bound on the bytes read from a companion file. We only keep the first
 // whitespace-delimited token, and the longest valid digest is sha-512 at 128
@@ -93,19 +86,17 @@ async function readCompanionFile(
 }
 
 /**
- * Given a Maven dependency ID (e.g. "com.google.guava:guava:jar:32.1.3-jre"),
- * read whichever companion checksum files exist for it in the local Maven
- * repository and return them as `hash:<algorithm>` -> hex labels.
+ * Given the path to an artifact in the local Maven repository, read whichever
+ * companion checksum files exist for it and return them as
+ * `hash:<algorithm>` -> hex labels.
  *
  * Empty result if none are present (artifact not in .m2 yet, or no companion
  * files published).
  */
 export async function readM2HashLabels(
-  dependencyId: string,
-  repositoryPath: string,
+  artifactPath: string,
 ): Promise<Record<string, string>> {
   const labels: Record<string, string> = {};
-  const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
 
   const digests = await Promise.all(
     M2_COMPANION_FILES.map(({ ext, digestPattern }) =>
@@ -121,40 +112,4 @@ export async function readM2HashLabels(
   });
 
   return labels;
-}
-
-/**
- * Pre-compute the hash-label map for every node in a set of Maven graphs.
- * Mirrors the pattern used by `generateFingerprints` so the depgraph builder
- * can attach labels without doing I/O inside the BFS/DFS loop. Reads are run
- * asynchronously in bounded batches so they never block the event loop.
- */
-export async function buildM2HashLabelsMap(
-  mavenGraphs: MavenGraph[],
-  repositoryPath: string,
-): Promise<Map<string, Record<string, string>>> {
-  const result = new Map<string, Record<string, string>>();
-
-  // Collect the unique node IDs across all graphs.
-  const nodeIds = new Set<string>();
-  for (const graph of mavenGraphs) {
-    Object.keys(graph.nodes).forEach((nodeId) => nodeIds.add(nodeId));
-  }
-  const nodeIdArray = Array.from(nodeIds);
-
-  // Read companion files in bounded-concurrency batches.
-  for (let i = 0; i < nodeIdArray.length; i += CONCURRENCY) {
-    const batch = nodeIdArray.slice(i, i + CONCURRENCY);
-    const batchResults = await Promise.all(
-      batch.map((nodeId) => readM2HashLabels(nodeId, repositoryPath)),
-    );
-    batch.forEach((nodeId, j) => {
-      const labels = batchResults[j];
-      if (Object.keys(labels).length > 0) {
-        result.set(nodeId, labels);
-      }
-    });
-  }
-
-  return result;
 }

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -56,13 +56,12 @@ export async function fetchRepositoryUrlMap(
     }
 
     // Forward the user's Maven args (the same ones passed to the resolve/tree
-    // pipeline). This is required, not cosmetic: the repo id recorded in an
-    // artifact's _remote.repositories is a *config-local* id resolved from the
-    // effective settings/profiles/mirrors (under a mirror it is the mirror id,
-    // e.g. `google-gcs-mirror`, not `central`). If list-repositories runs under
-    // a different effective config than the build that cached the artifacts, the
-    // ids won't line up and the join drops the label. Appended last to mirror
-    // the dependency-tree pipeline's arg order.
+    // pipeline). This is required, not cosmetic: the repo ids recorded in
+    // _remote.repositories are resolved from the effective
+    // settings/profiles/mirrors, so if list-repositories runs under a different
+    // config than the build that cached the artifacts, the ids won't line up and
+    // the join drops the label (see the mirror handling below). Appended last to
+    // mirror the dependency-tree pipeline's arg order.
     args.push(...mavenArgs);
 
     const stdout = await subProcess.execute(context.command, args, {
@@ -136,13 +135,17 @@ const MAX_REMOTE_REPOSITORIES_BYTES = 64 * 1024;
  * Maven writes this file when an artifact is installed from a remote repository.
  * Format: lines like `guava-32.1.3-jre.jar>central=`
  *
- * We prefer to read the repository ID from the `.jar` (or `.aar`, `.war`, `.ear`)
- * entry, as that's the artifact we're reporting on. Falls back to `.pom` if no
- * binary artifact entry is found. Returns undefined if the file is absent or
- * unparseable.
+ * We read the repository ID from the entry for the artifact we're reporting on
+ * (`artifactFileName`, e.g. `guava-32.1.3-jre.jar`) — matching by exact filename
+ * so a co-located `-sources.jar`/`-javadoc.jar` from a different repo can't win.
+ * An empty id on that entry means the artifact was installed locally (no remote
+ * source), so we report none rather than falling back. Falls back to the sibling
+ * `.pom` only when the artifact's own entry is absent. Returns undefined if the
+ * file is absent, unparseable, or records no remote source.
  */
 async function parseRemoteRepositoriesFile(
   filePath: string,
+  artifactFileName: string,
 ): Promise<string | undefined> {
   let content: string;
   let handle: fs.promises.FileHandle | undefined;
@@ -166,6 +169,8 @@ async function parseRemoteRepositoriesFile(
 
   const lines = content.split('\n');
 
+  // Sibling POM for the fallback, e.g. `foo-1.0.jar` -> `foo-1.0.pom`.
+  const pomFileName = artifactFileName.replace(/\.[^.]+$/, '.pom');
   let pomRepoId: string | undefined;
 
   for (const line of lines) {
@@ -181,35 +186,23 @@ async function parseRemoteRepositoriesFile(
       continue;
     }
     const filename = parts[0];
-    const repoAndRest = parts[1];
-    const repoId = repoAndRest.split('=')[0];
+    const repoId = parts[1].split('=')[0];
 
-    if (!repoId) {
-      continue;
+    // The artifact's own entry is authoritative: an empty id here means it was
+    // installed locally, so report no remote source rather than borrowing the
+    // .pom's.
+    if (filename === artifactFileName) {
+      return repoId || undefined;
     }
 
-    // Prefer JAR-like artifacts over .pom
-    if (
-      filename.endsWith('.jar') ||
-      filename.endsWith('.aar') ||
-      filename.endsWith('.war') ||
-      filename.endsWith('.ear')
-    ) {
-      return repoId;
-    }
-
-    // Remember .pom as a fallback
-    if (filename.endsWith('.pom') && !pomRepoId) {
+    // Remember the sibling .pom as a fallback for when the artifact's own entry
+    // is absent.
+    if (filename === pomFileName && repoId && !pomRepoId) {
       pomRepoId = repoId;
     }
   }
 
-  // Return .pom repo ID if no binary artifact was found
-  if (pomRepoId) {
-    return pomRepoId;
-  }
-
-  return undefined;
+  return pomRepoId;
 }
 
 /**
@@ -223,19 +216,12 @@ async function parseRemoteRepositoriesFile(
 export async function readRemoteRepositoryId(
   node: M2Node,
 ): Promise<string | undefined> {
-  try {
-    const versionDir = path.dirname(node.artifactPath);
-    const remoteReposFile = path.join(versionDir, '_remote.repositories');
-    return await parseRemoteRepositoriesFile(remoteReposFile);
-  } catch (err) {
-    // Any unexpected error: treat as "no remote repository recorded".
-    debug(
-      `Failed to read remote repository id for ${node.nodeId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-    return undefined;
-  }
+  // parseRemoteRepositoriesFile handles its own I/O errors and never throws;
+  // the path operations here can't throw either, so no guard is needed.
+  const versionDir = path.dirname(node.artifactPath);
+  const remoteReposFile = path.join(versionDir, '_remote.repositories');
+  const artifactFileName = path.basename(node.artifactPath);
+  return parseRemoteRepositoriesFile(remoteReposFile, artifactFileName);
 }
 
 /**

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -260,25 +260,6 @@ export function buildDistributionUrlLabel(
   return { 'distribution:url': fullUrl };
 }
 
-/**
- * Given a Maven node (dependency ID + resolved artifact path), read its
- * _remote.repositories file (if present), extract the repository ID, look it up
- * in the provided URL map, and construct the full artifact URL.
- *
- * Returns `{ 'distribution:url': <url> }` when resolvable, empty object otherwise.
- */
-export async function readRemoteRepositoryLabel(
-  node: M2Node,
-  repositoryPath: string,
-  repoUrlMap: Map<string, string>,
-): Promise<Record<string, string>> {
-  const repoId = await readRemoteRepositoryId(node);
-  if (!repoId) {
-    return {};
-  }
-  return buildDistributionUrlLabel(node, repoId, repositoryPath, repoUrlMap);
-}
-
 // Internal key used to carry each node's recorded repo ID through the shared
 // buildLabelMap batching primitive during the I/O phase, before the URL join.
 const REPO_ID_KEY = 'repoId';

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -264,9 +264,7 @@ async function parseRemoteRepositoriesFile(
  * Returns the recorded repository IDs (in file order), or an empty array if no
  * file/entry is present.
  */
-export async function readRemoteRepositoryIds(
-  node: M2Node,
-): Promise<string[]> {
+export async function readRemoteRepositoryIds(node: M2Node): Promise<string[]> {
   // parseRemoteRepositoriesFile handles its own I/O errors and never throws;
   // the path operations here can't throw either, so no guard is needed.
   const versionDir = path.dirname(node.artifactPath);

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as subProcess from '../sub-process';
-import type { MavenGraph } from './types';
 import type { MavenContext } from '../maven/context';
-import { dependencyIdToArtifactPath } from '../fingerprint';
+import type { M2Node } from './m2-batch';
 import { debug } from '../index';
 
 /**
@@ -76,7 +75,9 @@ export async function fetchRepositoryUrlMap(
     // empty map. Artifacts whose repos aren't in the map will simply
     // not get a distribution:url label (graceful degradation).
     debug(
-      `Failed to fetch repository URLs: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to fetch repository URLs: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
   }
 
@@ -152,24 +153,21 @@ async function parseRemoteRepositoriesFile(
 }
 
 /**
- * Given a Maven dependency ID, read its _remote.repositories file (if present),
- * extract the repository ID, look it up in the provided URL map, and construct
- * the full artifact URL.
+ * Given a Maven node (dependency ID + resolved artifact path), read its
+ * _remote.repositories file (if present), extract the repository ID, look it up
+ * in the provided URL map, and construct the full artifact URL.
  *
  * Returns `{ 'distribution:url': <url> }` when resolvable, empty object otherwise.
  */
-async function readRemoteRepositoryLabel(
-  dependencyId: string,
+export async function readRemoteRepositoryLabel(
+  node: M2Node,
   repositoryPath: string,
   repoUrlMap: Map<string, string>,
 ): Promise<Record<string, string>> {
+  const { nodeId, artifactPath } = node;
   const labels: Record<string, string> = {};
 
   try {
-    const artifactPath = dependencyIdToArtifactPath(
-      dependencyId,
-      repositoryPath,
-    );
     const versionDir = path.dirname(artifactPath);
     const remoteReposFile = path.join(versionDir, '_remote.repositories');
 
@@ -197,59 +195,15 @@ async function readRemoteRepositoryLabel(
     const fullUrl = `${repoUrl}/${relativePath}`;
     labels['distribution:url'] = fullUrl;
 
-    debug(
-      `Resolved distribution URL for ${dependencyId}: ${fullUrl}`,
-    );
+    debug(`Resolved distribution URL for ${nodeId}: ${fullUrl}`);
   } catch (err) {
     // Any unexpected error: just skip the label.
     debug(
-      `Failed to read remote repository label for ${dependencyId}: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to read remote repository label for ${nodeId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
   }
 
   return labels;
-}
-
-/**
- * Number of artifacts processed per batch. We batch to avoid spawning too many
- * concurrent file reads.
- */
-const CONCURRENCY = 5;
-
-/**
- * Pre-compute the distribution-URL label map for every node in a set of Maven
- * graphs. Returns Map<nodeId, { 'distribution:url': url }>, only storing entries
- * where a URL was successfully resolved.
- */
-export async function buildRemoteRepositoriesMap(
-  mavenGraphs: MavenGraph[],
-  repositoryPath: string,
-  repoUrlMap: Map<string, string>,
-): Promise<Map<string, Record<string, string>>> {
-  const result = new Map<string, Record<string, string>>();
-
-  // Collect the unique node IDs across all graphs.
-  const nodeIds = new Set<string>();
-  for (const graph of mavenGraphs) {
-    Object.keys(graph.nodes).forEach((nodeId) => nodeIds.add(nodeId));
-  }
-  const nodeIdArray = Array.from(nodeIds);
-
-  // Read _remote.repositories files in bounded-concurrency batches.
-  for (let i = 0; i < nodeIdArray.length; i += CONCURRENCY) {
-    const batch = nodeIdArray.slice(i, i + CONCURRENCY);
-    const batchResults = await Promise.all(
-      batch.map((nodeId) =>
-        readRemoteRepositoryLabel(nodeId, repositoryPath, repoUrlMap),
-      ),
-    );
-    batch.forEach((nodeId, j) => {
-      const labels = batchResults[j];
-      if (Object.keys(labels).length > 0) {
-        result.set(nodeId, labels);
-      }
-    });
-  }
-
-  return result;
 }

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as subProcess from '../sub-process';
 import type { MavenContext } from '../maven/context';
 import { MAVEN_DEPENDENCY_PLUGIN_VERSION } from '../maven/version';
-import { buildLabelMap, type M2Node } from './m2-batch';
+import { mapNodes, type M2Node } from './m2-batch';
 import { debug } from '../index';
 
 /**
@@ -260,10 +260,6 @@ export function buildDistributionUrlLabel(
   return { 'distribution:url': fullUrl };
 }
 
-// Internal key used to carry each node's recorded repo ID through the shared
-// buildLabelMap batching primitive during the I/O phase, before the URL join.
-const REPO_ID_KEY = 'repoId';
-
 /**
  * Build the distribution:url label map for a set of nodes in two phases so the
  * file I/O overlaps the (slow, JVM-startup) dependency:list-repositories
@@ -282,13 +278,12 @@ export async function buildRemoteRepositoryLabelMap(
   repositoryPath: string,
   repoUrlMapPromise: Promise<Map<string, string>>,
 ): Promise<Map<string, Record<string, string>>> {
-  // Phase 1 — pure I/O, overlaps the subprocess.
-  const repoIdLabels = await buildLabelMap(
+  // Phase 1 — pure I/O, overlaps the subprocess. Keep only nodes whose
+  // _remote.repositories recorded a repo id.
+  const repoIdByNode = await mapNodes(
     m2Nodes,
-    async (node): Promise<Record<string, string>> => {
-      const repoId = await readRemoteRepositoryId(node);
-      return repoId ? { [REPO_ID_KEY]: repoId } : {};
-    },
+    (node) => readRemoteRepositoryId(node),
+    (repoId) => repoId !== undefined,
   );
 
   // Phase 2 — join against the fetched map (by now usually already resolved).
@@ -296,7 +291,7 @@ export async function buildRemoteRepositoryLabelMap(
 
   const result = new Map<string, Record<string, string>>();
   for (const node of m2Nodes) {
-    const repoId = repoIdLabels.get(node.nodeId)?.[REPO_ID_KEY];
+    const repoId = repoIdByNode.get(node.nodeId);
     if (!repoId) {
       continue;
     }

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -1,0 +1,237 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import { exec } from 'child_process';
+import type { MavenGraph } from './types';
+import { dependencyIdToArtifactPath } from '../fingerprint';
+import { debug } from '../index';
+
+const execAsync = promisify(exec);
+
+/**
+ * Read the Maven remote repositories for a project by running
+ * `mvn dependency:list-repositories` and parsing the output.
+ *
+ * The output lists all repositories available to the project, including those
+ * configured in pom.xml, settings.xml, and super-POMs. In aggregate builds
+ * (multi-module), we capture repos from all modules and return a union.
+ *
+ * Returns a Map<repositoryId, repositoryUrl> for known repositories, or an
+ * empty map if the command fails or produces no output. Never throws.
+ */
+export async function fetchRepositoryUrlMap(
+  mavenCommand: string,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+
+  try {
+    const { stdout } = await execAsync(
+      `${mavenCommand} dependency:list-repositories`,
+    );
+
+    // Parse repository entries from Maven output.
+    // Format: ` * <id> (<url>, <layout>, <policy>)`
+    // We match lines that don't start with [INFO] (the repo entries).
+    // A regex like `/^\s+\*\s+(\S+)\s+\(([^,]+),/` captures:
+    // - Group 1: repository id
+    // - Group 2: repository url (everything before the first comma inside parens)
+    const repoLineRegex = /^\s+\*\s+(\S+)\s+\(([^,]+),/m;
+    const lines = stdout.split('\n');
+
+    for (const line of lines) {
+      const match = line.match(repoLineRegex);
+      if (!match) {
+        continue;
+      }
+      const repoId = match[1];
+      const repoUrl = match[2];
+
+      // Skip if we've already seen this repo ID (should be rare, but
+      // in the case of duplicate repo IDs we keep the first occurrence).
+      if (!result.has(repoId)) {
+        result.set(repoId, repoUrl);
+        debug(`Found repository: ${repoId} -> ${repoUrl}`);
+      }
+    }
+  } catch (err) {
+    // If the command fails or produces an error, we'll work with an
+    // empty map. Artifacts whose repos aren't in the map will simply
+    // not get a distribution:url label (graceful degradation).
+    debug(
+      `Failed to fetch repository URLs: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Read the _remote.repositories file for a given artifact version directory.
+ *
+ * Maven writes this file when an artifact is installed from a remote repository.
+ * Format: lines like `guava-32.1.3-jre.jar>central=`
+ *
+ * We prefer to read the repository ID from the `.jar` (or `.aar`, `.war`, `.ear`)
+ * entry, as that's the artifact we're reporting on. Falls back to `.pom` if no
+ * binary artifact entry is found. Returns undefined if the file is absent or
+ * unparseable.
+ */
+async function parseRemoteRepositoriesFile(
+  filePath: string,
+): Promise<string | undefined> {
+  try {
+    const content = await fs.promises.readFile(filePath, 'utf-8');
+    const lines = content.split('\n');
+
+    let pomRepoId: string | undefined;
+
+    for (const line of lines) {
+      // Skip comments and empty lines
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+
+      // Parse: `<filename>><repoId>=`
+      const parts = trimmed.split('>');
+      if (parts.length !== 2) {
+        continue;
+      }
+      const filename = parts[0];
+      const repoAndRest = parts[1];
+      const repoId = repoAndRest.split('=')[0];
+
+      if (!repoId) {
+        continue;
+      }
+
+      // Prefer JAR-like artifacts over .pom
+      if (
+        filename.endsWith('.jar') ||
+        filename.endsWith('.aar') ||
+        filename.endsWith('.war') ||
+        filename.endsWith('.ear')
+      ) {
+        return repoId;
+      }
+
+      // Remember .pom as a fallback
+      if (filename.endsWith('.pom') && !pomRepoId) {
+        pomRepoId = repoId;
+      }
+    }
+
+    // Return .pom repo ID if no binary artifact was found
+    if (pomRepoId) {
+      return pomRepoId;
+    }
+  } catch {
+    // File does not exist, is unreadable, or is malformed.
+    // Return undefined to signal "no remote repository recorded".
+  }
+
+  return undefined;
+}
+
+/**
+ * Given a Maven dependency ID, read its _remote.repositories file (if present),
+ * extract the repository ID, look it up in the provided URL map, and construct
+ * the full artifact URL.
+ *
+ * Returns `{ 'distribution:url': <url> }` when resolvable, empty object otherwise.
+ */
+async function readRemoteRepositoryLabel(
+  dependencyId: string,
+  repositoryPath: string,
+  repoUrlMap: Map<string, string>,
+): Promise<Record<string, string>> {
+  const labels: Record<string, string> = {};
+
+  try {
+    const artifactPath = dependencyIdToArtifactPath(
+      dependencyId,
+      repositoryPath,
+    );
+    const versionDir = path.dirname(artifactPath);
+    const remoteReposFile = path.join(versionDir, '_remote.repositories');
+
+    const repoId = await parseRemoteRepositoriesFile(remoteReposFile);
+    if (!repoId) {
+      return labels;
+    }
+
+    const repoUrl = repoUrlMap.get(repoId);
+    if (!repoUrl) {
+      // Repo ID found in _remote.repositories but not in our fetched URL map.
+      // This can happen if the artifact was cached by another project or if the
+      // repository is not listed in the current project's dependency:list-repositories.
+      // Gracefully degrade: no distribution:url label for this artifact.
+      debug(
+        `Repository ID '${repoId}' from ${remoteReposFile} not found in fetched repo map`,
+      );
+      return labels;
+    }
+
+    // Construct the full artifact URL by appending the relative path from the repo root.
+    const relativePath = path
+      .relative(repositoryPath, artifactPath)
+      .replace(/\\/g, '/');
+    const fullUrl = `${repoUrl}/${relativePath}`;
+    labels['distribution:url'] = fullUrl;
+
+    debug(
+      `Resolved distribution URL for ${dependencyId}: ${fullUrl}`,
+    );
+  } catch (err) {
+    // Any unexpected error: just skip the label.
+    debug(
+      `Failed to read remote repository label for ${dependencyId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return labels;
+}
+
+/**
+ * Number of artifacts processed per batch. We batch to avoid spawning too many
+ * concurrent file reads.
+ */
+const CONCURRENCY = 5;
+
+/**
+ * Pre-compute the distribution-URL label map for every node in a set of Maven
+ * graphs. Returns Map<nodeId, { 'distribution:url': url }>, only storing entries
+ * where a URL was successfully resolved.
+ */
+export async function buildRemoteRepositoriesMap(
+  mavenGraphs: MavenGraph[],
+  repositoryPath: string,
+  repoUrlMap: Map<string, string>,
+): Promise<Map<string, Record<string, string>>> {
+  const result = new Map<string, Record<string, string>>();
+
+  // Collect the unique node IDs across all graphs.
+  const nodeIds = new Set<string>();
+  for (const graph of mavenGraphs) {
+    Object.keys(graph.nodes).forEach((nodeId) => nodeIds.add(nodeId));
+  }
+  const nodeIdArray = Array.from(nodeIds);
+
+  // Read _remote.repositories files in bounded-concurrency batches.
+  for (let i = 0; i < nodeIdArray.length; i += CONCURRENCY) {
+    const batch = nodeIdArray.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map((nodeId) =>
+        readRemoteRepositoryLabel(nodeId, repositoryPath, repoUrlMap),
+      ),
+    );
+    batch.forEach((nodeId, j) => {
+      const labels = batchResults[j];
+      if (Object.keys(labels).length > 0) {
+        result.set(nodeId, labels);
+      }
+    });
+  }
+
+  return result;
+}

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -69,28 +69,42 @@ export async function fetchRepositoryUrlMap(
       cwd: context.workingDirectory,
     });
 
-    // Parse repository entries from Maven output.
-    // Format: ` * <id> (<url>, <layout>, <policy>)`
-    // We match lines that don't start with [INFO] (the repo entries).
-    // A regex like `/^\s+\*\s+(\S+)\s+\(([^,]+),/` captures:
-    // - Group 1: repository id
-    // - Group 2: repository url (everything before the first comma inside parens)
-    const repoLineRegex = /^\s+\*\s+(\S+)\s+\(([^,]+),/m;
+    // Parse repository entries from Maven output. A repo line looks like:
+    //    * central (https://repo.maven.apache.org/maven2, default, releases)
+    // and, when a mirror is active, carries a trailing mirror clause:
+    //    * central (https://…/maven2, default, releases) mirrored by google-gcs-mirror (https://mirror/…, default, releases)
+    //
+    // We record BOTH the logical id and the mirror id, each mapped to its own
+    // URL. This is essential, not redundant: the id written to an artifact's
+    // _remote.repositories is the *mirror* id when a mirror is active (e.g.
+    // `google-gcs-mirror`, not `central`), so keying only on the logical id
+    // would never match a mirrored build and no label would be emitted. Mapping
+    // each id to its own URL lets the recorded id pick the right source — the
+    // mirror URL for a mirrored artifact, which is where the bytes came from.
+    //
+    // Group 1: repository/mirror id. Group 2: URL up to the first comma in parens.
+    const repoLineRegex = /^\s+\*\s+(\S+)\s+\(([^,]+),/;
+    const mirrorRegex = /\bmirrored by\s+(\S+)\s+\(([^,]+),/;
     const lines = stdout.split('\n');
+
+    // Keep the first URL seen for a given id (duplicates should be rare).
+    const addRepo = (id: string, url: string): void => {
+      if (!result.has(id)) {
+        result.set(id, url);
+        debug(`Found repository: ${id} -> ${url}`);
+      }
+    };
 
     for (const line of lines) {
       const match = line.match(repoLineRegex);
       if (!match) {
         continue;
       }
-      const repoId = match[1];
-      const repoUrl = match[2];
+      addRepo(match[1], match[2]);
 
-      // Skip if we've already seen this repo ID (should be rare, but
-      // in the case of duplicate repo IDs we keep the first occurrence).
-      if (!result.has(repoId)) {
-        result.set(repoId, repoUrl);
-        debug(`Found repository: ${repoId} -> ${repoUrl}`);
+      const mirrorMatch = line.match(mirrorRegex);
+      if (mirrorMatch) {
+        addRepo(mirrorMatch[1], mirrorMatch[2]);
       }
     }
   } catch (err) {

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as subProcess from '../sub-process';
 import type { MavenContext } from '../maven/context';
 import { MAVEN_DEPENDENCY_PLUGIN_VERSION } from '../maven/version';
-import type { M2Node } from './m2-batch';
+import { buildLabelMap, type M2Node } from './m2-batch';
 import { debug } from '../index';
 
 /**
@@ -188,6 +188,68 @@ async function parseRemoteRepositoriesFile(
 }
 
 /**
+ * Read the repository ID recorded for an artifact in its _remote.repositories
+ * file. This is the I/O half of the distribution:url pass and depends only on
+ * the local Maven repository — never on the fetched repo→URL map — so it can be
+ * run concurrently with the dependency:list-repositories subprocess.
+ *
+ * Returns the repository ID, or undefined if no file/entry is present.
+ */
+export async function readRemoteRepositoryId(
+  node: M2Node,
+): Promise<string | undefined> {
+  try {
+    const versionDir = path.dirname(node.artifactPath);
+    const remoteReposFile = path.join(versionDir, '_remote.repositories');
+    return await parseRemoteRepositoriesFile(remoteReposFile);
+  } catch (err) {
+    // Any unexpected error: treat as "no remote repository recorded".
+    debug(
+      `Failed to read remote repository id for ${node.nodeId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Join a recorded repository ID against the fetched repo→URL map to construct
+ * the artifact's distribution:url label. Pure in-memory work — no I/O.
+ *
+ * Returns `{ 'distribution:url': <url> }` when resolvable, empty object otherwise.
+ */
+export function buildDistributionUrlLabel(
+  node: M2Node,
+  repoId: string,
+  repositoryPath: string,
+  repoUrlMap: Map<string, string>,
+): Record<string, string> {
+  const repoUrl = repoUrlMap.get(repoId);
+  if (!repoUrl) {
+    // Repo ID found in _remote.repositories but not in our fetched URL map.
+    // This can happen if the artifact was cached by another project or if the
+    // repository is not listed in the current project's dependency:list-repositories.
+    // Gracefully degrade: no distribution:url label for this artifact.
+    debug(
+      `Repository ID '${repoId}' for ${node.nodeId} not found in fetched repo map`,
+    );
+    return {};
+  }
+
+  // Construct the full artifact URL by appending the relative path from the
+  // repo root. Repo URLs from settings.xml/mirrors often carry a trailing
+  // slash (e.g. `https://repo.maven.apache.org/maven2/`); strip it so we
+  // don't emit a `…/maven2//com/google/…` double slash.
+  const relativePath = path
+    .relative(repositoryPath, node.artifactPath)
+    .replace(/\\/g, '/');
+  const fullUrl = `${repoUrl.replace(/\/+$/, '')}/${relativePath}`;
+  debug(`Resolved distribution URL for ${node.nodeId}: ${fullUrl}`);
+  return { 'distribution:url': fullUrl };
+}
+
+/**
  * Given a Maven node (dependency ID + resolved artifact path), read its
  * _remote.repositories file (if present), extract the repository ID, look it up
  * in the provided URL map, and construct the full artifact URL.
@@ -199,49 +261,63 @@ export async function readRemoteRepositoryLabel(
   repositoryPath: string,
   repoUrlMap: Map<string, string>,
 ): Promise<Record<string, string>> {
-  const { nodeId, artifactPath } = node;
-  const labels: Record<string, string> = {};
+  const repoId = await readRemoteRepositoryId(node);
+  if (!repoId) {
+    return {};
+  }
+  return buildDistributionUrlLabel(node, repoId, repositoryPath, repoUrlMap);
+}
 
-  try {
-    const versionDir = path.dirname(artifactPath);
-    const remoteReposFile = path.join(versionDir, '_remote.repositories');
+// Internal key used to carry each node's recorded repo ID through the shared
+// buildLabelMap batching primitive during the I/O phase, before the URL join.
+const REPO_ID_KEY = 'repoId';
 
-    const repoId = await parseRemoteRepositoriesFile(remoteReposFile);
+/**
+ * Build the distribution:url label map for a set of nodes in two phases so the
+ * file I/O overlaps the (slow, JVM-startup) dependency:list-repositories
+ * subprocess:
+ *
+ *   1. Read every node's recorded repository ID from its _remote.repositories
+ *      file — bounded-concurrency I/O that needs nothing from the subprocess.
+ *   2. Once the repo→URL map resolves, join each ID to a URL in memory.
+ *
+ * `repoUrlMapPromise` is awaited only after phase 1's reads complete, so as long
+ * as the caller kicks the subprocess off before calling this, the reads run
+ * alongside it rather than serially after it.
+ */
+export async function buildRemoteRepositoryLabelMap(
+  m2Nodes: M2Node[],
+  repositoryPath: string,
+  repoUrlMapPromise: Promise<Map<string, string>>,
+): Promise<Map<string, Record<string, string>>> {
+  // Phase 1 — pure I/O, overlaps the subprocess.
+  const repoIdLabels = await buildLabelMap(
+    m2Nodes,
+    async (node): Promise<Record<string, string>> => {
+      const repoId = await readRemoteRepositoryId(node);
+      return repoId ? { [REPO_ID_KEY]: repoId } : {};
+    },
+  );
+
+  // Phase 2 — join against the fetched map (by now usually already resolved).
+  const repoUrlMap = await repoUrlMapPromise;
+
+  const result = new Map<string, Record<string, string>>();
+  for (const node of m2Nodes) {
+    const repoId = repoIdLabels.get(node.nodeId)?.[REPO_ID_KEY];
     if (!repoId) {
-      return labels;
+      continue;
     }
-
-    const repoUrl = repoUrlMap.get(repoId);
-    if (!repoUrl) {
-      // Repo ID found in _remote.repositories but not in our fetched URL map.
-      // This can happen if the artifact was cached by another project or if the
-      // repository is not listed in the current project's dependency:list-repositories.
-      // Gracefully degrade: no distribution:url label for this artifact.
-      debug(
-        `Repository ID '${repoId}' from ${remoteReposFile} not found in fetched repo map`,
-      );
-      return labels;
-    }
-
-    // Construct the full artifact URL by appending the relative path from the
-    // repo root. Repo URLs from settings.xml/mirrors often carry a trailing
-    // slash (e.g. `https://repo.maven.apache.org/maven2/`); strip it so we
-    // don't emit a `…/maven2//com/google/…` double slash.
-    const relativePath = path
-      .relative(repositoryPath, artifactPath)
-      .replace(/\\/g, '/');
-    const fullUrl = `${repoUrl.replace(/\/+$/, '')}/${relativePath}`;
-    labels['distribution:url'] = fullUrl;
-
-    debug(`Resolved distribution URL for ${nodeId}: ${fullUrl}`);
-  } catch (err) {
-    // Any unexpected error: just skip the label.
-    debug(
-      `Failed to read remote repository label for ${nodeId}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+    const label = buildDistributionUrlLabel(
+      node,
+      repoId,
+      repositoryPath,
+      repoUrlMap,
     );
+    if (Object.keys(label).length > 0) {
+      result.set(node.nodeId, label);
+    }
   }
 
-  return labels;
+  return result;
 }

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -84,6 +84,15 @@ export async function fetchRepositoryUrlMap(
   return result;
 }
 
+// Upper bound on the bytes read from a _remote.repositories file. Each line is
+// a short `<filename>><repoId>=` record and a version directory lists only a
+// handful of artifacts, so a real file is well under 1 KiB even for heavily
+// classified artifacts. 64 KiB is generous headroom while stopping a
+// misconfigured mirror that stored a large HTML error page at this path from
+// being buffered wholesale. If a file somehow exceeds this we parse the prefix
+// we read — the .jar/.pom records are listed near the top.
+const MAX_REMOTE_REPOSITORIES_BYTES = 64 * 1024;
+
 /**
  * Read the _remote.repositories file for a given artifact version directory.
  *
@@ -98,55 +107,69 @@ export async function fetchRepositoryUrlMap(
 async function parseRemoteRepositoriesFile(
   filePath: string,
 ): Promise<string | undefined> {
+  let content: string;
+  let handle: fs.promises.FileHandle | undefined;
   try {
-    const content = await fs.promises.readFile(filePath, 'utf-8');
-    const lines = content.split('\n');
-
-    let pomRepoId: string | undefined;
-
-    for (const line of lines) {
-      // Skip comments and empty lines
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) {
-        continue;
-      }
-
-      // Parse: `<filename>><repoId>=`
-      const parts = trimmed.split('>');
-      if (parts.length !== 2) {
-        continue;
-      }
-      const filename = parts[0];
-      const repoAndRest = parts[1];
-      const repoId = repoAndRest.split('=')[0];
-
-      if (!repoId) {
-        continue;
-      }
-
-      // Prefer JAR-like artifacts over .pom
-      if (
-        filename.endsWith('.jar') ||
-        filename.endsWith('.aar') ||
-        filename.endsWith('.war') ||
-        filename.endsWith('.ear')
-      ) {
-        return repoId;
-      }
-
-      // Remember .pom as a fallback
-      if (filename.endsWith('.pom') && !pomRepoId) {
-        pomRepoId = repoId;
-      }
-    }
-
-    // Return .pom repo ID if no binary artifact was found
-    if (pomRepoId) {
-      return pomRepoId;
-    }
+    handle = await fs.promises.open(filePath, 'r');
+    const buffer = Buffer.alloc(MAX_REMOTE_REPOSITORIES_BYTES);
+    const { bytesRead } = await handle.read(
+      buffer,
+      0,
+      MAX_REMOTE_REPOSITORIES_BYTES,
+      0,
+    );
+    content = buffer.toString('utf8', 0, bytesRead);
   } catch {
     // File does not exist, is unreadable, or is malformed.
     // Return undefined to signal "no remote repository recorded".
+    return undefined;
+  } finally {
+    await handle?.close();
+  }
+
+  const lines = content.split('\n');
+
+  let pomRepoId: string | undefined;
+
+  for (const line of lines) {
+    // Skip comments and empty lines
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    // Parse: `<filename>><repoId>=`
+    const parts = trimmed.split('>');
+    if (parts.length !== 2) {
+      continue;
+    }
+    const filename = parts[0];
+    const repoAndRest = parts[1];
+    const repoId = repoAndRest.split('=')[0];
+
+    if (!repoId) {
+      continue;
+    }
+
+    // Prefer JAR-like artifacts over .pom
+    if (
+      filename.endsWith('.jar') ||
+      filename.endsWith('.aar') ||
+      filename.endsWith('.war') ||
+      filename.endsWith('.ear')
+    ) {
+      return repoId;
+    }
+
+    // Remember .pom as a fallback
+    if (filename.endsWith('.pom') && !pomRepoId) {
+      pomRepoId = repoId;
+    }
+  }
+
+  // Return .pom repo ID if no binary artifact was found
+  if (pomRepoId) {
+    return pomRepoId;
   }
 
   return undefined;
@@ -188,11 +211,14 @@ export async function readRemoteRepositoryLabel(
       return labels;
     }
 
-    // Construct the full artifact URL by appending the relative path from the repo root.
+    // Construct the full artifact URL by appending the relative path from the
+    // repo root. Repo URLs from settings.xml/mirrors often carry a trailing
+    // slash (e.g. `https://repo.maven.apache.org/maven2/`); strip it so we
+    // don't emit a `…/maven2//com/google/…` double slash.
     const relativePath = path
       .relative(repositoryPath, artifactPath)
       .replace(/\\/g, '/');
-    const fullUrl = `${repoUrl}/${relativePath}`;
+    const fullUrl = `${repoUrl.replace(/\/+$/, '')}/${relativePath}`;
     labels['distribution:url'] = fullUrl;
 
     debug(`Resolved distribution URL for ${nodeId}: ${fullUrl}`);

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as subProcess from '../sub-process';
 import type { MavenContext } from '../maven/context';
+import { MAVEN_DEPENDENCY_PLUGIN_VERSION } from '../maven/version';
 import type { M2Node } from './m2-batch';
 import { debug } from '../index';
 
@@ -19,6 +20,7 @@ import { debug } from '../index';
 export async function fetchRepositoryUrlMap(
   context: MavenContext,
   mavenAggregateProject: boolean,
+  pluginVersion: string = MAVEN_DEPENDENCY_PLUGIN_VERSION,
 ): Promise<Map<string, string>> {
   const result = new Map<string, string>();
 
@@ -27,7 +29,17 @@ export async function fetchRepositoryUrlMap(
     // project's repositories: run from the Maven working directory, scope to the
     // target pom, and use --batch-mode to disable interactive prompts and
     // download-progress/colour noise that would break the line parsing below.
-    const args = ['dependency:list-repositories', '--batch-mode'];
+    //
+    // Pin the plugin version rather than using the bare `dependency:` prefix:
+    // the goal's output format is version-dependent — 3.6.1+ emits the
+    // single-line ` * <id> (<url>, ...)` form the regex below parses, whereas
+    // 2.x emits a multi-line `id:`/`url:` block we would not match (and 2.x
+    // also omits some repositories entirely). Pinning to the same version the
+    // rest of the pipeline uses keeps the output parseable and complete.
+    const args = [
+      `org.apache.maven.plugins:maven-dependency-plugin:${pluginVersion}:list-repositories`,
+      '--batch-mode',
+    ];
 
     if (context.targetFile && !mavenAggregateProject) {
       // if we are where we can execute - we preserve the original path;

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -7,14 +7,39 @@ import { mapNodes, type M2Node } from './m2-batch';
 import { debug } from '../index';
 
 /**
+ * A repository entry from `dependency:list-repositories`: its URL, plus its
+ * `rank` — the 0-based position it appeared at in the output. `list-repositories`
+ * prints repositories in Maven's search/priority order (project- and
+ * dependency-declared repos before `central`), so a lower rank means a
+ * higher-priority repository. When an artifact's _remote.repositories records
+ * more than one repo id (see `parseRemoteRepositoriesFile`), the rank breaks the
+ * tie: we credit the highest-priority (lowest-rank) recorded repo, matching the
+ * repo Maven itself would have preferred.
+ *
+ * Caveat: rank is assigned by first occurrence across the whole (flat) output.
+ * In an aggregate reactor the aggregator section often lists `central` first, so
+ * `central` can grab rank 0 globally even though a child module declares a
+ * higher-priority repo. That aggregate imprecision is rare, and the recorded
+ * per-artifact repo signal is itself unreliable in multi-module builds sharing
+ * one cache; the rank is exact wherever there is a single module (the common
+ * case). The real fix would be per-module ranks, deliberately deferred.
+ */
+export interface RepositoryEntry {
+  url: string;
+  rank: number;
+}
+
+/**
  * Read the Maven remote repositories for a project by running
  * `mvn dependency:list-repositories` and parsing the output.
  *
  * The output lists all repositories available to the project, including those
- * configured in pom.xml, settings.xml, and super-POMs. In aggregate builds
- * (multi-module), we capture repos from all modules and return a union.
+ * configured in pom.xml, settings.xml, super-POMs, AND those introduced by
+ * dependency POMs (e.g. a dependency that declares its own <repositories>). In
+ * aggregate builds (multi-module), we capture repos from all modules and return
+ * a union.
  *
- * Returns a Map<repositoryId, repositoryUrl> for known repositories, or an
+ * Returns a Map<repositoryId, RepositoryEntry> for known repositories, or an
  * empty map if the command fails or produces no output. Never throws.
  */
 export async function fetchRepositoryUrlMap(
@@ -22,8 +47,8 @@ export async function fetchRepositoryUrlMap(
   mavenAggregateProject: boolean,
   pluginVersion: string = MAVEN_DEPENDENCY_PLUGIN_VERSION,
   mavenArgs: string[] = [],
-): Promise<Map<string, string>> {
-  const result = new Map<string, string>();
+): Promise<Map<string, RepositoryEntry>> {
+  const result = new Map<string, RepositoryEntry>();
 
   try {
     // Mirror the dependency-tree pipeline's invocation so we resolve the same
@@ -46,8 +71,15 @@ export async function fetchRepositoryUrlMap(
       // if we are where we can execute - we preserve the original path;
       // if not - we rely on the executor (mvnw) to be spawned at the closest
       // directory, leaving us w/ the file itself.
+      //
       // In aggregate (multi-module) builds we omit --file so Maven walks every
-      // module and we capture the union of their repositories.
+      // module and we capture the union of their repositories. We deliberately
+      // do NOT use --non-recursive here: a child module's <repositories> are not
+      // inherited by the aggregator, so a non-recursive run against the parent
+      // would report only the parent's repos and miss module-specific ones. The
+      // recursive run already prints a per-module section, which is enough to
+      // union every repo id in play (running each module non-recursively would
+      // spawn N subprocesses for the same information).
       if (context.root === context.workingDirectory) {
         args.push('--file', context.targetFile);
       } else {
@@ -86,11 +118,14 @@ export async function fetchRepositoryUrlMap(
     const mirrorRegex = /\bmirrored by\s+(\S+)\s+\(([^,]+),/;
     const lines = stdout.split('\n');
 
-    // Keep the first URL seen for a given id (duplicates should be rare).
+    // Keep the first URL seen for a given id (duplicates should be rare) and
+    // stamp it with the rank of that first occurrence — its position in the
+    // priority-ordered output. `result.size` is the next free rank because we
+    // only ever insert new ids here.
     const addRepo = (id: string, url: string): void => {
       if (!result.has(id)) {
-        result.set(id, url);
-        debug(`Found repository: ${id} -> ${url}`);
+        result.set(id, { url, rank: result.size });
+        debug(`Found repository (rank ${result.size - 1}): ${id} -> ${url}`);
       }
     };
 
@@ -135,18 +170,21 @@ const MAX_REMOTE_REPOSITORIES_BYTES = 64 * 1024;
  * Maven writes this file when an artifact is installed from a remote repository.
  * Format: lines like `guava-32.1.3-jre.jar>central=`
  *
- * We read the repository ID from the entry for the artifact we're reporting on
+ * We read the repository IDs from the entry for the artifact we're reporting on
  * (`artifactFileName`, e.g. `guava-32.1.3-jre.jar`) — matching by exact filename
  * so a co-located `-sources.jar`/`-javadoc.jar` from a different repo can't win.
+ * A single artifact can accumulate more than one id (a shared/warm cache appends
+ * every repo it was ever resolved against), so we return ALL ids recorded for
+ * that entry, in file order; the caller picks the highest-priority one by rank.
  * An empty id on that entry means the artifact was installed locally (no remote
  * source), so we report none rather than falling back. Falls back to the sibling
- * `.pom` only when the artifact's own entry is absent. Returns undefined if the
- * file is absent, unparseable, or records no remote source.
+ * `.pom`'s ids only when the artifact's own entry is absent. Returns an empty
+ * array if the file is absent, unparseable, or records no remote source.
  */
 async function parseRemoteRepositoriesFile(
   filePath: string,
   artifactFileName: string,
-): Promise<string | undefined> {
+): Promise<string[]> {
   let content: string;
   let handle: fs.promises.FileHandle | undefined;
   try {
@@ -161,8 +199,8 @@ async function parseRemoteRepositoriesFile(
     content = buffer.toString('utf8', 0, bytesRead);
   } catch {
     // File does not exist, is unreadable, or is malformed.
-    // Return undefined to signal "no remote repository recorded".
-    return undefined;
+    // Return an empty array to signal "no remote repository recorded".
+    return [];
   } finally {
     await handle?.close();
   }
@@ -171,7 +209,9 @@ async function parseRemoteRepositoriesFile(
 
   // Sibling POM for the fallback, e.g. `foo-1.0.jar` -> `foo-1.0.pom`.
   const pomFileName = artifactFileName.replace(/\.[^.]+$/, '.pom');
-  let pomRepoId: string | undefined;
+  const artifactRepoIds: string[] = [];
+  const pomRepoIds: string[] = [];
+  let sawArtifactEntry = false;
 
   for (const line of lines) {
     // Skip comments and empty lines
@@ -188,34 +228,45 @@ async function parseRemoteRepositoriesFile(
     const filename = parts[0];
     const repoId = parts[1].split('=')[0];
 
-    // The artifact's own entry is authoritative: an empty id here means it was
-    // installed locally, so report no remote source rather than borrowing the
-    // .pom's.
+    // The artifact's own entry is authoritative. Collect every id recorded for
+    // it. An empty id means it was installed locally; we track that the entry
+    // exists (sawArtifactEntry) so we don't borrow the .pom's ids, but we don't
+    // add the empty id itself.
     if (filename === artifactFileName) {
-      return repoId || undefined;
+      sawArtifactEntry = true;
+      if (repoId) {
+        artifactRepoIds.push(repoId);
+      }
+      continue;
     }
 
-    // Remember the sibling .pom as a fallback for when the artifact's own entry
-    // is absent.
-    if (filename === pomFileName && repoId && !pomRepoId) {
-      pomRepoId = repoId;
+    // Remember the sibling .pom's ids as a fallback for when the artifact's own
+    // entry is absent.
+    if (filename === pomFileName && repoId) {
+      pomRepoIds.push(repoId);
     }
   }
 
-  return pomRepoId;
+  // The artifact's own entry wins outright when present (even if it recorded
+  // only an empty local id); only fall back to the .pom when it is absent.
+  if (sawArtifactEntry) {
+    return artifactRepoIds;
+  }
+  return pomRepoIds;
 }
 
 /**
- * Read the repository ID recorded for an artifact in its _remote.repositories
+ * Read the repository IDs recorded for an artifact in its _remote.repositories
  * file. This is the I/O half of the distribution:url pass and depends only on
  * the local Maven repository — never on the fetched repo→URL map — so it can be
  * run concurrently with the dependency:list-repositories subprocess.
  *
- * Returns the repository ID, or undefined if no file/entry is present.
+ * Returns the recorded repository IDs (in file order), or an empty array if no
+ * file/entry is present.
  */
-export async function readRemoteRepositoryId(
+export async function readRemoteRepositoryIds(
   node: M2Node,
-): Promise<string | undefined> {
+): Promise<string[]> {
   // parseRemoteRepositoriesFile handles its own I/O errors and never throws;
   // the path operations here can't throw either, so no guard is needed.
   const versionDir = path.dirname(node.artifactPath);
@@ -225,25 +276,40 @@ export async function readRemoteRepositoryId(
 }
 
 /**
- * Join a recorded repository ID against the fetched repo→URL map to construct
- * the artifact's distribution:url label. Pure in-memory work — no I/O.
+ * Join an artifact's recorded repository IDs against the fetched repo→entry map
+ * to construct its distribution:url label. Pure in-memory work — no I/O.
+ *
+ * When more than one id was recorded (a shared/warm cache accumulates every repo
+ * the artifact was resolved against), we credit the highest-priority repo: a
+ * single linear pass over the recorded ids picks the one with the lowest rank
+ * (earliest in dependency:list-repositories' priority order). Ids absent from
+ * the map are skipped, so an unmatched id degrades gracefully rather than losing
+ * the label — a lower-priority-but-known repo can still win the URL.
  *
  * Returns `{ 'distribution:url': <url> }` when resolvable, empty object otherwise.
  */
 export function buildDistributionUrlLabel(
   node: M2Node,
-  repoId: string,
+  repoIds: string[],
   repositoryPath: string,
-  repoUrlMap: Map<string, string>,
+  repoUrlMap: Map<string, RepositoryEntry>,
 ): Record<string, string> {
-  const repoUrl = repoUrlMap.get(repoId);
-  if (!repoUrl) {
-    // Repo ID found in _remote.repositories but not in our fetched URL map.
-    // This can happen if the artifact was cached by another project or if the
-    // repository is not listed in the current project's dependency:list-repositories.
-    // Gracefully degrade: no distribution:url label for this artifact.
+  let best: RepositoryEntry | undefined;
+  for (const repoId of repoIds) {
+    const entry = repoUrlMap.get(repoId);
+    // undefined ⇒ id recorded in _remote.repositories but not in our fetched
+    // map (e.g. cached by another project, or not in this project's
+    // list-repositories); skip it and let a known repo win instead.
+    if (entry && (!best || entry.rank < best.rank)) {
+      best = entry;
+    }
+  }
+
+  if (!best) {
     debug(
-      `Repository ID '${repoId}' for ${node.nodeId} not found in fetched repo map`,
+      `None of the recorded repository IDs [${repoIds.join(', ')}] for ${
+        node.nodeId
+      } were found in the fetched repo map`,
     );
     return {};
   }
@@ -255,7 +321,7 @@ export function buildDistributionUrlLabel(
   const relativePath = path
     .relative(repositoryPath, node.artifactPath)
     .replace(/\\/g, '/');
-  const fullUrl = `${repoUrl.replace(/\/+$/, '')}/${relativePath}`;
+  const fullUrl = `${best.url.replace(/\/+$/, '')}/${relativePath}`;
   debug(`Resolved distribution URL for ${node.nodeId}: ${fullUrl}`);
   return { 'distribution:url': fullUrl };
 }
@@ -276,14 +342,14 @@ export function buildDistributionUrlLabel(
 export async function buildRemoteRepositoryLabelMap(
   m2Nodes: M2Node[],
   repositoryPath: string,
-  repoUrlMapPromise: Promise<Map<string, string>>,
+  repoUrlMapPromise: Promise<Map<string, RepositoryEntry>>,
 ): Promise<Map<string, Record<string, string>>> {
   // Phase 1 — pure I/O, overlaps the subprocess. Keep only nodes whose
-  // _remote.repositories recorded a repo id.
-  const repoIdByNode = await mapNodes(
+  // _remote.repositories recorded at least one repo id.
+  const repoIdsByNode = await mapNodes(
     m2Nodes,
-    (node) => readRemoteRepositoryId(node),
-    (repoId) => repoId !== undefined,
+    (node) => readRemoteRepositoryIds(node),
+    (repoIds) => repoIds.length > 0,
   );
 
   // Phase 2 — join against the fetched map (by now usually already resolved).
@@ -291,13 +357,13 @@ export async function buildRemoteRepositoryLabelMap(
 
   const result = new Map<string, Record<string, string>>();
   for (const node of m2Nodes) {
-    const repoId = repoIdByNode.get(node.nodeId);
-    if (!repoId) {
+    const repoIds = repoIdsByNode.get(node.nodeId);
+    if (!repoIds) {
       continue;
     }
     const label = buildDistributionUrlLabel(
       node,
-      repoId,
+      repoIds,
       repositoryPath,
       repoUrlMap,
     );

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -21,6 +21,7 @@ export async function fetchRepositoryUrlMap(
   context: MavenContext,
   mavenAggregateProject: boolean,
   pluginVersion: string = MAVEN_DEPENDENCY_PLUGIN_VERSION,
+  mavenArgs: string[] = [],
 ): Promise<Map<string, string>> {
   const result = new Map<string, string>();
 
@@ -53,6 +54,16 @@ export async function fetchRepositoryUrlMap(
         args.push('--file', path.basename(context.targetFile));
       }
     }
+
+    // Forward the user's Maven args (the same ones passed to the resolve/tree
+    // pipeline). This is required, not cosmetic: the repo id recorded in an
+    // artifact's _remote.repositories is a *config-local* id resolved from the
+    // effective settings/profiles/mirrors (under a mirror it is the mirror id,
+    // e.g. `google-gcs-mirror`, not `central`). If list-repositories runs under
+    // a different effective config than the build that cached the artifacts, the
+    // ids won't line up and the join drops the label. Appended last to mirror
+    // the dependency-tree pipeline's arg order.
+    args.push(...mavenArgs);
 
     const stdout = await subProcess.execute(context.command, args, {
       cwd: context.workingDirectory,

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -1,12 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { promisify } from 'util';
-import { exec } from 'child_process';
+import * as subProcess from '../sub-process';
 import type { MavenGraph } from './types';
+import type { MavenContext } from '../maven/context';
 import { dependencyIdToArtifactPath } from '../fingerprint';
 import { debug } from '../index';
-
-const execAsync = promisify(exec);
 
 /**
  * Read the Maven remote repositories for a project by running
@@ -20,14 +18,34 @@ const execAsync = promisify(exec);
  * empty map if the command fails or produces no output. Never throws.
  */
 export async function fetchRepositoryUrlMap(
-  mavenCommand: string,
+  context: MavenContext,
+  mavenAggregateProject: boolean,
 ): Promise<Map<string, string>> {
   const result = new Map<string, string>();
 
   try {
-    const { stdout } = await execAsync(
-      `${mavenCommand} dependency:list-repositories`,
-    );
+    // Mirror the dependency-tree pipeline's invocation so we resolve the same
+    // project's repositories: run from the Maven working directory, scope to the
+    // target pom, and use --batch-mode to disable interactive prompts and
+    // download-progress/colour noise that would break the line parsing below.
+    const args = ['dependency:list-repositories', '--batch-mode'];
+
+    if (context.targetFile && !mavenAggregateProject) {
+      // if we are where we can execute - we preserve the original path;
+      // if not - we rely on the executor (mvnw) to be spawned at the closest
+      // directory, leaving us w/ the file itself.
+      // In aggregate (multi-module) builds we omit --file so Maven walks every
+      // module and we capture the union of their repositories.
+      if (context.root === context.workingDirectory) {
+        args.push('--file', context.targetFile);
+      } else {
+        args.push('--file', path.basename(context.targetFile));
+      }
+    }
+
+    const stdout = await subProcess.execute(context.command, args, {
+      cwd: context.workingDirectory,
+    });
 
     // Parse repository entries from Maven output.
     // Format: ` * <id> (<url>, <layout>, <policy>)`

--- a/lib/parse/scanned-project-builder.ts
+++ b/lib/parse/scanned-project-builder.ts
@@ -11,6 +11,7 @@ export function buildScannedProjects(
   includePurl = false,
   showMavenBuildScope = false,
   hashLabelsMap = new Map<string, Record<string, string>>(),
+  remoteRepositoriesMap = new Map<string, Record<string, string>>(),
 ): { scannedProjects: ScannedProject[] } {
   const context: ParseContext = {
     includeTestScope,
@@ -19,6 +20,7 @@ export function buildScannedProjects(
     includePurl,
     showMavenBuildScope,
     hashLabelsMap,
+    remoteRepositoriesMap,
   };
 
   const scannedProjects: ScannedProject[] = [];

--- a/lib/parse/types.ts
+++ b/lib/parse/types.ts
@@ -97,4 +97,10 @@ export interface ParseContext {
   // node ID and contains zero or more `hash:<algorithm>` -> hex digest pairs.
   // See lib/parse/m2-hash-labels.ts.
   hashLabelsMap?: Map<string, Record<string, string>>;
+  // Per-node distribution-source labels read from the local Maven repository's
+  // _remote.repositories files and resolved to full artifact URLs via Maven's
+  // dependency:list-repositories. Each entry is keyed by Maven node ID and
+  // contains zero or one `distribution:url` -> full URL pair.
+  // See lib/parse/m2-remote-repositories.ts.
+  remoteRepositoriesMap?: Map<string, Record<string, string>>;
 }

--- a/tests/jest/functional/m2-hash-labels.spec.ts
+++ b/tests/jest/functional/m2-hash-labels.spec.ts
@@ -5,11 +5,10 @@ import * as path from 'path';
 
 import { parseDigraphs } from '../../../lib/parse/digraph';
 import { buildDepGraph } from '../../../lib/parse/dep-graph';
-import {
-  buildM2HashLabelsMap,
-  readM2HashLabels,
-} from '../../../lib/parse/m2-hash-labels';
-import type { ParseContext } from '../../../lib/parse/types';
+import { readM2HashLabels } from '../../../lib/parse/m2-hash-labels';
+import { collectM2Nodes, buildLabelMap } from '../../../lib/parse/m2-batch';
+import { dependencyIdToArtifactPath } from '../../../lib/fingerprint';
+import type { MavenGraph, ParseContext } from '../../../lib/parse/types';
 
 // Helper: write a fake artifact JAR plus the three companion files Maven
 // would have written when it pulled the artifact from a registry. The JAR
@@ -41,6 +40,14 @@ function writeFakeArtifact(
 
   // Return the JAR path so callers can tweak individual companion files.
   return jarPath;
+}
+
+// Mirror the production pipeline's hash-label pass: resolve the graph nodes to
+// artifact paths once, then read each node's companion-file hashes.
+function buildHashLabelsMap(graphs: MavenGraph[], repoRoot: string) {
+  return buildLabelMap(collectM2Nodes(graphs, repoRoot), (node) =>
+    readM2HashLabels(node.artifactPath),
+  );
 }
 
 describe('Maven hash:<alg> label emission from .m2 companion files', () => {
@@ -94,8 +101,10 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
   describe('readM2HashLabels', () => {
     it('reads md5/sha-1/sha-256 from companion files', async () => {
       const labels = await readM2HashLabels(
-        'com.google.guava:guava:jar:32.1.3-jre',
-        repoRoot,
+        dependencyIdToArtifactPath(
+          'com.google.guava:guava:jar:32.1.3-jre',
+          repoRoot,
+        ),
       );
       expect(labels).toEqual(
         acceptedHashes['com.google.guava:guava:jar:32.1.3-jre'],
@@ -104,8 +113,10 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
 
     it('returns an empty object when the artifact is not in the repository', async () => {
       const labels = await readM2HashLabels(
-        'org.unknown:nothing-here:jar:0.0.0',
-        repoRoot,
+        dependencyIdToArtifactPath(
+          'org.unknown:nothing-here:jar:0.0.0',
+          repoRoot,
+        ),
       );
       expect(labels).toEqual({});
     });
@@ -123,8 +134,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       fs.unlinkSync(`${jarPath}.sha256`);
 
       const labels = await readM2HashLabels(
-        'com.example:no-sha256:jar:1.0.0',
-        repoRoot,
+        dependencyIdToArtifactPath('com.example:no-sha256:jar:1.0.0', repoRoot),
       );
       expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
     });
@@ -146,8 +156,10 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       );
 
       const labels = await readM2HashLabels(
-        'com.example:html-sha256:jar:1.0.0',
-        repoRoot,
+        dependencyIdToArtifactPath(
+          'com.example:html-sha256:jar:1.0.0',
+          repoRoot,
+        ),
       );
       expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
       expect(labels['hash:sha-256']).toBeUndefined();
@@ -165,8 +177,10 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       fs.writeFileSync(`${jarPath}.sha256`, 'deadbeef\n');
 
       const labels = await readM2HashLabels(
-        'com.example:short-sha256:jar:1.0.0',
-        repoRoot,
+        dependencyIdToArtifactPath(
+          'com.example:short-sha256:jar:1.0.0',
+          repoRoot,
+        ),
       );
       expect(labels['hash:sha-256']).toBeUndefined();
     });
@@ -179,7 +193,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       }`;
       const mavenGraph = parseDigraphs([diGraph])[0];
 
-      const hashLabelsMap = await buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const hashLabelsMap = await buildHashLabelsMap([mavenGraph], repoRoot);
       const context: ParseContext = {
         includeTestScope: false,
         verboseEnabled: false,
@@ -218,7 +232,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       }`;
       const mavenGraph = parseDigraphs([diGraph])[0];
 
-      const hashLabelsMap = await buildM2HashLabelsMap([mavenGraph], repoRoot);
+      const hashLabelsMap = await buildHashLabelsMap([mavenGraph], repoRoot);
       const context: ParseContext = {
         includeTestScope: false,
         verboseEnabled: false,

--- a/tests/jest/functional/m2-remote-repositories-parse.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories-parse.spec.ts
@@ -1,0 +1,128 @@
+import * as subProcess from '../../../lib/sub-process';
+import { fetchRepositoryUrlMap } from '../../../lib/parse/m2-remote-repositories';
+import type { MavenContext } from '../../../lib/maven/context';
+
+jest.mock('../../../lib/sub-process');
+
+const mockedExecute = subProcess.execute as jest.MockedFunction<
+  typeof subProcess.execute
+>;
+
+const context: MavenContext = {
+  command: 'mvn',
+  workingDirectory: '/project',
+  root: '/project',
+  targetFile: 'pom.xml',
+  targetPath: '/project/pom.xml',
+};
+
+// Captured verbatim from `mvn dependency:list-repositories --batch-mode` on a
+// maven-dependency-plugin 3.x invocation. Repo entries are single ` * <id> (<url>,
+// <layout>, <policy>)` lines with no `[INFO]` prefix; everything else is noise the
+// parser must skip.
+const SINGLE_REPO_STDOUT = `[INFO] Scanning for projects...
+[INFO]
+[INFO] --- dependency:3.9.0:list-repositories (default-cli) @ test-project ---
+[INFO] Project remote repositories used by this build:
+ * central (https://repo.maven.apache.org/maven2, default, releases)
+
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+`;
+
+const MULTI_REPO_STDOUT = `[INFO] Scanning for projects...
+[INFO] --- dependency:3.9.0:list-repositories (default-cli) @ snapshot-parent ---
+[WARNING] The POM for io.snyk.os-managed:snapshot-child:jar:1.0.1-SNAPSHOT is missing, no dependency information available
+[INFO] Project remote repositories used by this build:
+ * local-snapshots (https://nexus.fake.invalid/repository/local-snapshots/, default, releases+snapshots)
+ * central (https://repo.maven.apache.org/maven2, default, releases)
+
+[INFO] BUILD SUCCESS
+`;
+
+describe('fetchRepositoryUrlMap output parsing', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('parses a single repository entry', async () => {
+    mockedExecute.mockResolvedValue(SINGLE_REPO_STDOUT);
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
+    expect(map.size).toBe(1);
+  });
+
+  it('parses multiple repositories into a single union map', async () => {
+    mockedExecute.mockResolvedValue(MULTI_REPO_STDOUT);
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
+    // A trailing slash from settings.xml/mirror is preserved as-is; the join in
+    // readRemoteRepositoryLabel is responsible for normalising it, not the parse.
+    expect(map.get('local-snapshots')).toBe(
+      'https://nexus.fake.invalid/repository/local-snapshots/',
+    );
+    expect(map.size).toBe(2);
+  });
+
+  it('ignores [INFO]/[WARNING] and other non-repository lines', async () => {
+    mockedExecute.mockResolvedValue(MULTI_REPO_STDOUT);
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    // Only the two ` * <id> (...)` lines become entries; header/warning/build
+    // lines must not leak in as bogus repo ids.
+    expect([...map.keys()].sort()).toEqual(['central', 'local-snapshots']);
+  });
+
+  it('keeps the first occurrence when a repository id is repeated', async () => {
+    mockedExecute.mockResolvedValue(
+      `[INFO] Project remote repositories used by this build:
+ * central (https://first.example/maven2, default, releases)
+ * central (https://second.example/maven2, default, releases)
+`,
+    );
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    expect(map.get('central')).toBe('https://first.example/maven2');
+    expect(map.size).toBe(1);
+  });
+
+  it('returns an empty map when no repository lines are present', async () => {
+    mockedExecute.mockResolvedValue(
+      `[INFO] Project remote repositories used by this build:
+[INFO] BUILD SUCCESS
+`,
+    );
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('returns an empty map (never throws) when the goal fails', async () => {
+    mockedExecute.mockRejectedValue(new Error('mvn exited with code 1'));
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('pins the maven-dependency-plugin version on the invoked goal', async () => {
+    mockedExecute.mockResolvedValue(SINGLE_REPO_STDOUT);
+
+    await fetchRepositoryUrlMap(context, false, '3.9.0');
+
+    const invokedArgs = mockedExecute.mock.calls[0][1] as string[];
+    // Pinned goal, not the bare `dependency:list-repositories`, so the output
+    // format is deterministic (3.x single-line form) regardless of the plugin
+    // version the project would otherwise resolve.
+    expect(invokedArgs[0]).toBe(
+      'org.apache.maven.plugins:maven-dependency-plugin:3.9.0:list-repositories',
+    );
+    expect(invokedArgs).toContain('--batch-mode');
+  });
+});

--- a/tests/jest/functional/m2-remote-repositories-parse.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories-parse.spec.ts
@@ -125,4 +125,21 @@ describe('fetchRepositoryUrlMap output parsing', () => {
     );
     expect(invokedArgs).toContain('--batch-mode');
   });
+
+  it('forwards the user maven args so the effective config matches the build', async () => {
+    mockedExecute.mockResolvedValue(SINGLE_REPO_STDOUT);
+
+    await fetchRepositoryUrlMap(context, false, '3.9.0', [
+      '-s',
+      'corporate-settings.xml',
+      '-Pinternal',
+    ]);
+
+    const invokedArgs = mockedExecute.mock.calls[0][1] as string[];
+    // Without these, list-repositories runs under a different effective config
+    // than the resolve/tree pipeline and the recorded repo ids won't line up.
+    expect(invokedArgs).toEqual(
+      expect.arrayContaining(['-s', 'corporate-settings.xml', '-Pinternal']),
+    );
+  });
 });

--- a/tests/jest/functional/m2-remote-repositories-parse.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories-parse.spec.ts
@@ -72,7 +72,7 @@ describe('fetchRepositoryUrlMap output parsing', () => {
 
     expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
     // A trailing slash from settings.xml/mirror is preserved as-is; the join in
-    // readRemoteRepositoryLabel is responsible for normalising it, not the parse.
+    // buildDistributionUrlLabel is responsible for normalising it, not the parse.
     expect(map.get('local-snapshots')).toBe(
       'https://nexus.fake.invalid/repository/local-snapshots/',
     );

--- a/tests/jest/functional/m2-remote-repositories-parse.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories-parse.spec.ts
@@ -61,21 +61,30 @@ describe('fetchRepositoryUrlMap output parsing', () => {
 
     const map = await fetchRepositoryUrlMap(context, false);
 
-    expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
+    expect(map.get('central')).toEqual({
+      url: 'https://repo.maven.apache.org/maven2',
+      rank: 0,
+    });
     expect(map.size).toBe(1);
   });
 
-  it('parses multiple repositories into a single union map', async () => {
+  it('parses multiple repositories into a single union map, ranked in output order', async () => {
     mockedExecute.mockResolvedValue(MULTI_REPO_STDOUT);
 
     const map = await fetchRepositoryUrlMap(context, false);
 
-    expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
-    // A trailing slash from settings.xml/mirror is preserved as-is; the join in
-    // buildDistributionUrlLabel is responsible for normalising it, not the parse.
-    expect(map.get('local-snapshots')).toBe(
-      'https://nexus.fake.invalid/repository/local-snapshots/',
-    );
+    // list-repositories prints repos in priority order; rank captures that so a
+    // multi-id artifact can pick the highest-priority (lowest-rank) repo.
+    expect(map.get('local-snapshots')).toEqual({
+      // A trailing slash from settings.xml/mirror is preserved as-is; the join in
+      // buildDistributionUrlLabel normalises it, not the parse.
+      url: 'https://nexus.fake.invalid/repository/local-snapshots/',
+      rank: 0,
+    });
+    expect(map.get('central')).toEqual({
+      url: 'https://repo.maven.apache.org/maven2',
+      rank: 1,
+    });
     expect(map.size).toBe(2);
   });
 
@@ -84,14 +93,18 @@ describe('fetchRepositoryUrlMap output parsing', () => {
 
     const map = await fetchRepositoryUrlMap(context, false);
 
+    // The logical id is parsed first (rank 0), the mirror id second (rank 1);
+    // an artifact recording both prefers the canonical central URL by rank.
+    expect(map.get('central')).toEqual({
+      url: 'https://repo.maven.apache.org/maven2',
+      rank: 0,
+    });
     // _remote.repositories records the mirror id under a mirror, so this entry
-    // is the one that actually resolves labels — pointing at the mirror URL.
-    expect(map.get('google-gcs-mirror')).toBe(
-      'https://maven-central.storage-download.googleapis.com/maven2/',
-    );
-    // The logical id is still recorded (its own URL) for the rare artifact that
-    // recorded `central` directly.
-    expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
+    // is what resolves labels for a mirrored artifact — pointing at the mirror URL.
+    expect(map.get('google-gcs-mirror')).toEqual({
+      url: 'https://maven-central.storage-download.googleapis.com/maven2/',
+      rank: 1,
+    });
     expect(map.size).toBe(2);
   });
 
@@ -105,7 +118,7 @@ describe('fetchRepositoryUrlMap output parsing', () => {
     expect([...map.keys()].sort()).toEqual(['central', 'local-snapshots']);
   });
 
-  it('keeps the first occurrence when a repository id is repeated', async () => {
+  it('keeps the first occurrence (url and rank) when a repository id is repeated', async () => {
     mockedExecute.mockResolvedValue(
       `[INFO] Project remote repositories used by this build:
  * central (https://first.example/maven2, default, releases)
@@ -115,7 +128,10 @@ describe('fetchRepositoryUrlMap output parsing', () => {
 
     const map = await fetchRepositoryUrlMap(context, false);
 
-    expect(map.get('central')).toBe('https://first.example/maven2');
+    expect(map.get('central')).toEqual({
+      url: 'https://first.example/maven2',
+      rank: 0,
+    });
     expect(map.size).toBe(1);
   });
 

--- a/tests/jest/functional/m2-remote-repositories-parse.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories-parse.spec.ts
@@ -41,6 +41,18 @@ const MULTI_REPO_STDOUT = `[INFO] Scanning for projects...
 [INFO] BUILD SUCCESS
 `;
 
+// Captured with a mirror active (settings.xml with a <mirror> of central). The
+// repo entry carries a trailing `mirrored by <id> (<url>, ...)` clause. Under a
+// mirror, an artifact's _remote.repositories records the MIRROR id, so the map
+// must contain that id -> the mirror URL.
+const MIRRORED_STDOUT = `[INFO] Scanning for projects...
+[INFO] --- dependency:3.9.0:list-repositories (default-cli) @ google-project ---
+[INFO] Project remote repositories used by this build:
+ * central (https://repo.maven.apache.org/maven2, default, releases) mirrored by google-gcs-mirror (https://maven-central.storage-download.googleapis.com/maven2/, default, releases)
+
+[INFO] BUILD SUCCESS
+`;
+
 describe('fetchRepositoryUrlMap output parsing', () => {
   afterEach(() => jest.clearAllMocks());
 
@@ -64,6 +76,22 @@ describe('fetchRepositoryUrlMap output parsing', () => {
     expect(map.get('local-snapshots')).toBe(
       'https://nexus.fake.invalid/repository/local-snapshots/',
     );
+    expect(map.size).toBe(2);
+  });
+
+  it('records both the logical id and the mirror id, each with its own url', async () => {
+    mockedExecute.mockResolvedValue(MIRRORED_STDOUT);
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    // _remote.repositories records the mirror id under a mirror, so this entry
+    // is the one that actually resolves labels — pointing at the mirror URL.
+    expect(map.get('google-gcs-mirror')).toBe(
+      'https://maven-central.storage-download.googleapis.com/maven2/',
+    );
+    // The logical id is still recorded (its own URL) for the rare artifact that
+    // recorded `central` directly.
+    expect(map.get('central')).toBe('https://repo.maven.apache.org/maven2');
     expect(map.size).toBe(2);
   });
 

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -3,11 +3,24 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { dependencyIdToArtifactPath } from '../../../lib/fingerprint';
-import {
-  readRemoteRepositoryLabel,
-  buildRemoteRepositoryLabelMap,
-} from '../../../lib/parse/m2-remote-repositories';
+import { buildRemoteRepositoryLabelMap } from '../../../lib/parse/m2-remote-repositories';
 import type { M2Node } from '../../../lib/parse/m2-batch';
+
+// Resolve the label for a single node through the production path
+// (buildRemoteRepositoryLabelMap), returning {} when no label is emitted. Keeps
+// the per-node assertions below exercising the code that actually ships.
+async function labelFor(
+  node: M2Node,
+  repositoryPath: string,
+  urlMap: Map<string, string>,
+): Promise<Record<string, string>> {
+  const map = await buildRemoteRepositoryLabelMap(
+    [node],
+    repositoryPath,
+    Promise.resolve(urlMap),
+  );
+  return map.get(node.nodeId) ?? {};
+}
 
 describe('distribution:url label emission from .m2 _remote.repositories files', () => {
   let repoRoot: string;
@@ -41,7 +54,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
   });
 
   it('builds the artifact URL from the repo URL and the repo-relative path', async () => {
-    const labels = await readRemoteRepositoryLabel(
+    const labels = await labelFor(
       node,
       repoRoot,
       new Map([['central', 'https://repo.maven.apache.org/maven2']]),
@@ -50,7 +63,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
   });
 
   it('does not emit a double slash when the repo URL has a trailing slash', async () => {
-    const labels = await readRemoteRepositoryLabel(
+    const labels = await labelFor(
       node,
       repoRoot,
       new Map([['central', 'https://repo.maven.apache.org/maven2/']]),
@@ -59,7 +72,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
   });
 
   it('returns no label when the recorded repo id is not in the URL map', async () => {
-    const labels = await readRemoteRepositoryLabel(node, repoRoot, new Map());
+    const labels = await labelFor(node, repoRoot, new Map());
     expect(labels).toEqual({});
   });
 
@@ -69,7 +82,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
       nodeId: otherDepId,
       artifactPath: dependencyIdToArtifactPath(otherDepId, repoRoot),
     };
-    const labels = await readRemoteRepositoryLabel(
+    const labels = await labelFor(
       otherNode,
       repoRoot,
       new Map([['central', 'https://repo.maven.apache.org/maven2']]),
@@ -90,7 +103,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
       `#NOTE: internal Maven Resolver file\nclassified-1.0-sources.jar>other=\nclassified-1.0.jar>central=\n`,
     );
 
-    const labels = await readRemoteRepositoryLabel(
+    const labels = await labelFor(
       { nodeId: depId, artifactPath },
       repoRoot,
       new Map([
@@ -116,7 +129,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
       `#NOTE: internal Maven Resolver file\nlocal-1.0.pom>central=\nlocal-1.0.jar>=\n`,
     );
 
-    const labels = await readRemoteRepositoryLabel(
+    const labels = await labelFor(
       { nodeId: depId, artifactPath },
       repoRoot,
       new Map([['central', 'https://repo.maven.apache.org/maven2']]),

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -3,8 +3,22 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { dependencyIdToArtifactPath } from '../../../lib/fingerprint';
-import { buildRemoteRepositoryLabelMap } from '../../../lib/parse/m2-remote-repositories';
+import {
+  buildRemoteRepositoryLabelMap,
+  type RepositoryEntry,
+} from '../../../lib/parse/m2-remote-repositories';
 import type { M2Node } from '../../../lib/parse/m2-batch';
+
+// Build a repo→entry map from ordered [id, url] pairs, stamping rank by position
+// so the first pair is the highest priority — mirroring how fetchRepositoryUrlMap
+// ranks dependency:list-repositories output.
+function rankedMap(
+  ...pairs: [string, string][]
+): Map<string, RepositoryEntry> {
+  return new Map(
+    pairs.map(([id, url], rank) => [id, { url, rank }]),
+  );
+}
 
 // Resolve the label for a single node through the production path
 // (buildRemoteRepositoryLabelMap), returning {} when no label is emitted. Keeps
@@ -12,7 +26,7 @@ import type { M2Node } from '../../../lib/parse/m2-batch';
 async function labelFor(
   node: M2Node,
   repositoryPath: string,
-  urlMap: Map<string, string>,
+  urlMap: Map<string, RepositoryEntry>,
 ): Promise<Record<string, string>> {
   const map = await buildRemoteRepositoryLabelMap(
     [node],
@@ -57,7 +71,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     const labels = await labelFor(
       node,
       repoRoot,
-      new Map([['central', 'https://repo.maven.apache.org/maven2']]),
+      rankedMap(['central', 'https://repo.maven.apache.org/maven2']),
     );
     expect(labels['distribution:url']).toBe(expectedUrl);
   });
@@ -66,7 +80,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     const labels = await labelFor(
       node,
       repoRoot,
-      new Map([['central', 'https://repo.maven.apache.org/maven2/']]),
+      rankedMap(['central', 'https://repo.maven.apache.org/maven2/']),
     );
     expect(labels['distribution:url']).toBe(expectedUrl);
   });
@@ -85,7 +99,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     const labels = await labelFor(
       otherNode,
       repoRoot,
-      new Map([['central', 'https://repo.maven.apache.org/maven2']]),
+      rankedMap(['central', 'https://repo.maven.apache.org/maven2']),
     );
     expect(labels).toEqual({});
   });
@@ -106,10 +120,10 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     const labels = await labelFor(
       { nodeId: depId, artifactPath },
       repoRoot,
-      new Map([
+      rankedMap(
         ['central', 'https://repo.maven.apache.org/maven2'],
         ['other', 'https://other.example/maven2'],
-      ]),
+      ),
     );
     expect(labels['distribution:url']).toBe(
       'https://repo.maven.apache.org/maven2/com/example/classified/1.0/classified-1.0.jar',
@@ -132,9 +146,62 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     const labels = await labelFor(
       { nodeId: depId, artifactPath },
       repoRoot,
-      new Map([['central', 'https://repo.maven.apache.org/maven2']]),
+      rankedMap(['central', 'https://repo.maven.apache.org/maven2']),
     );
     expect(labels).toEqual({});
+  });
+
+  it('credits the highest-priority repo when a jar records multiple repo ids', async () => {
+    // Shared/warm cache: the jar accumulated both ids. list-repositories ranks
+    // jboss above central, so the label must resolve to jboss (rank 0), not
+    // whichever id happens to appear first in the file.
+    const depId = 'com.example:multi:jar:1.0';
+    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const dir = path.dirname(artifactPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(artifactPath, 'fake jar contents');
+    // central is written first in the file; jboss second. File order must not
+    // decide the winner — rank does.
+    fs.writeFileSync(
+      path.join(dir, '_remote.repositories'),
+      `#NOTE: internal Maven Resolver file\nmulti-1.0.jar>central=\nmulti-1.0.jar>jboss=\n`,
+    );
+
+    const labels = await labelFor(
+      { nodeId: depId, artifactPath },
+      repoRoot,
+      rankedMap(
+        ['jboss', 'https://repository.jboss.org/nexus/content/groups/public/'],
+        ['central', 'https://repo.maven.apache.org/maven2'],
+      ),
+    );
+    expect(labels['distribution:url']).toBe(
+      'https://repository.jboss.org/nexus/content/groups/public/com/example/multi/1.0/multi-1.0.jar',
+    );
+  });
+
+  it('falls back to a lower-priority recorded id when the top one is absent from the map', async () => {
+    // The jar records [jboss, central] but the fetched map only knows central
+    // (jboss missing, e.g. cached by another project). Rather than lose the
+    // label, we credit the known lower-priority repo.
+    const depId = 'com.example:partial:jar:1.0';
+    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const dir = path.dirname(artifactPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(artifactPath, 'fake jar contents');
+    fs.writeFileSync(
+      path.join(dir, '_remote.repositories'),
+      `#NOTE: internal Maven Resolver file\npartial-1.0.jar>jboss=\npartial-1.0.jar>central=\n`,
+    );
+
+    const labels = await labelFor(
+      { nodeId: depId, artifactPath },
+      repoRoot,
+      rankedMap(['central', 'https://repo.maven.apache.org/maven2']),
+    );
+    expect(labels['distribution:url']).toBe(
+      'https://repo.maven.apache.org/maven2/com/example/partial/1.0/partial-1.0.jar',
+    );
   });
 });
 
@@ -144,9 +211,7 @@ describe('buildRemoteRepositoryLabelMap two-phase build', () => {
   let jbossNode: M2Node; // records a repo id absent from the url map
   let noFileNode: M2Node; // installed jar but no _remote.repositories file
 
-  const urlMap = new Map([
-    ['central', 'https://repo.maven.apache.org/maven2'],
-  ]);
+  const urlMap = rankedMap(['central', 'https://repo.maven.apache.org/maven2']);
 
   function install(depId: string, repoId?: string): M2Node {
     const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
@@ -198,8 +263,8 @@ describe('buildRemoteRepositoryLabelMap two-phase build', () => {
     const openSpy = jest.spyOn(fs.promises, 'open');
 
     let mapResolved = false;
-    let resolveMap!: (m: Map<string, string>) => void;
-    const pendingMap = new Promise<Map<string, string>>((resolve) => {
+    let resolveMap!: (m: Map<string, RepositoryEntry>) => void;
+    const pendingMap = new Promise<Map<string, RepositoryEntry>>((resolve) => {
       resolveMap = (m) => {
         mapResolved = true;
         resolve(m);

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -3,7 +3,10 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { dependencyIdToArtifactPath } from '../../../lib/fingerprint';
-import { readRemoteRepositoryLabel } from '../../../lib/parse/m2-remote-repositories';
+import {
+  readRemoteRepositoryLabel,
+  buildRemoteRepositoryLabelMap,
+} from '../../../lib/parse/m2-remote-repositories';
 import type { M2Node } from '../../../lib/parse/m2-batch';
 
 describe('distribution:url label emission from .m2 _remote.repositories files', () => {
@@ -72,5 +75,96 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
       new Map([['central', 'https://repo.maven.apache.org/maven2']]),
     );
     expect(labels).toEqual({});
+  });
+});
+
+describe('buildRemoteRepositoryLabelMap two-phase build', () => {
+  let repoRoot: string;
+  let fooNode: M2Node; // has a _remote.repositories recording `central`
+  let jbossNode: M2Node; // records a repo id absent from the url map
+  let noFileNode: M2Node; // installed jar but no _remote.repositories file
+
+  const urlMap = new Map([
+    ['central', 'https://repo.maven.apache.org/maven2'],
+  ]);
+
+  function install(depId: string, repoId?: string): M2Node {
+    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const dir = path.dirname(artifactPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(artifactPath, 'fake jar contents');
+    if (repoId) {
+      const jarName = path.basename(artifactPath);
+      fs.writeFileSync(
+        path.join(dir, '_remote.repositories'),
+        `#NOTE: internal Maven Resolver file\n${jarName}>${repoId}=\n`,
+      );
+    }
+    return { nodeId: depId, artifactPath };
+  }
+
+  beforeAll(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'snyk-mvn-remote-map-'));
+    fooNode = install('com.example:foo:jar:1.0', 'central');
+    jbossNode = install('com.example:jboss-dep:jar:2.0', 'jboss');
+    noFileNode = install('com.example:nofile:jar:3.0');
+  });
+
+  afterAll(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('joins recorded repo ids to urls, dropping unmatched and file-less nodes', async () => {
+    const map = await buildRemoteRepositoryLabelMap(
+      [fooNode, jbossNode, noFileNode],
+      repoRoot,
+      Promise.resolve(urlMap),
+    );
+
+    expect(map.get(fooNode.nodeId)).toEqual({
+      'distribution:url':
+        'https://repo.maven.apache.org/maven2/com/example/foo/1.0/foo-1.0.jar',
+    });
+    // jboss recorded but not in the url map, nofile has no _remote.repositories.
+    expect(map.has(jbossNode.nodeId)).toBe(false);
+    expect(map.has(noFileNode.nodeId)).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  it('reads the _remote.repositories files before the url map resolves', async () => {
+    // Phase 1 (file I/O) must not be gated on the url map — that is what lets it
+    // overlap the dependency:list-repositories subprocess. Prove it by handing in
+    // an unresolved promise and asserting the reads have already happened.
+    const openSpy = jest.spyOn(fs.promises, 'open');
+
+    let mapResolved = false;
+    let resolveMap!: (m: Map<string, string>) => void;
+    const pendingMap = new Promise<Map<string, string>>((resolve) => {
+      resolveMap = (m) => {
+        mapResolved = true;
+        resolve(m);
+      };
+    });
+
+    const resultPromise = buildRemoteRepositoryLabelMap(
+      [fooNode],
+      repoRoot,
+      pendingMap,
+    );
+
+    // Let phase 1's batched reads run without resolving the map.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(openSpy).toHaveBeenCalled();
+    expect(mapResolved).toBe(false);
+
+    resolveMap(urlMap);
+    const map = await resultPromise;
+    expect(map.get(fooNode.nodeId)?.['distribution:url']).toBe(
+      'https://repo.maven.apache.org/maven2/com/example/foo/1.0/foo-1.0.jar',
+    );
+
+    openSpy.mockRestore();
   });
 });

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -76,6 +76,53 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     );
     expect(labels).toEqual({});
   });
+
+  it('ignores a co-located -sources.jar recorded against a different repo', async () => {
+    const depId = 'com.example:classified:jar:1.0';
+    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const dir = path.dirname(artifactPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(artifactPath, 'fake jar contents');
+    // The sources jar (from `other`) is listed before the main jar (`central`);
+    // the main artifact's own entry must win, not the first jar-like line.
+    fs.writeFileSync(
+      path.join(dir, '_remote.repositories'),
+      `#NOTE: internal Maven Resolver file\nclassified-1.0-sources.jar>other=\nclassified-1.0.jar>central=\n`,
+    );
+
+    const labels = await readRemoteRepositoryLabel(
+      { nodeId: depId, artifactPath },
+      repoRoot,
+      new Map([
+        ['central', 'https://repo.maven.apache.org/maven2'],
+        ['other', 'https://other.example/maven2'],
+      ]),
+    );
+    expect(labels['distribution:url']).toBe(
+      'https://repo.maven.apache.org/maven2/com/example/classified/1.0/classified-1.0.jar',
+    );
+  });
+
+  it('emits no label when the artifact was installed locally (empty repo id)', async () => {
+    const depId = 'com.example:local:jar:1.0';
+    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const dir = path.dirname(artifactPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(artifactPath, 'fake jar contents');
+    // Jar installed locally (empty id) but the pom came from central: the jar's
+    // own entry is authoritative, so we must not claim it came from central.
+    fs.writeFileSync(
+      path.join(dir, '_remote.repositories'),
+      `#NOTE: internal Maven Resolver file\nlocal-1.0.pom>central=\nlocal-1.0.jar>=\n`,
+    );
+
+    const labels = await readRemoteRepositoryLabel(
+      { nodeId: depId, artifactPath },
+      repoRoot,
+      new Map([['central', 'https://repo.maven.apache.org/maven2']]),
+    );
+    expect(labels).toEqual({});
+  });
 });
 
 describe('buildRemoteRepositoryLabelMap two-phase build', () => {

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { dependencyIdToArtifactPath } from '../../../lib/fingerprint';
+import { readRemoteRepositoryLabel } from '../../../lib/parse/m2-remote-repositories';
+import type { M2Node } from '../../../lib/parse/m2-batch';
+
+describe('distribution:url label emission from .m2 _remote.repositories files', () => {
+  let repoRoot: string;
+  let node: M2Node;
+
+  const depId = 'com.example:foo:jar:1.0';
+  const expectedUrl =
+    'https://repo.maven.apache.org/maven2/com/example/foo/1.0/foo-1.0.jar';
+
+  beforeAll(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'snyk-mvn-remote-'));
+
+    // Stand up a fake installed artifact plus the _remote.repositories file
+    // Maven writes alongside it, recording the repo the jar came from.
+    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const dir = path.dirname(artifactPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(artifactPath, 'fake jar contents');
+    fs.writeFileSync(
+      path.join(dir, '_remote.repositories'),
+      // A leading comment line (Maven writes a header + timestamp), the pom
+      // entry, then the jar entry — the jar is preferred.
+      `#NOTE: internal Maven Resolver file\nfoo-1.0.pom>central=\nfoo-1.0.jar>central=\n`,
+    );
+
+    node = { nodeId: depId, artifactPath };
+  });
+
+  afterAll(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('builds the artifact URL from the repo URL and the repo-relative path', async () => {
+    const labels = await readRemoteRepositoryLabel(
+      node,
+      repoRoot,
+      new Map([['central', 'https://repo.maven.apache.org/maven2']]),
+    );
+    expect(labels['distribution:url']).toBe(expectedUrl);
+  });
+
+  it('does not emit a double slash when the repo URL has a trailing slash', async () => {
+    const labels = await readRemoteRepositoryLabel(
+      node,
+      repoRoot,
+      new Map([['central', 'https://repo.maven.apache.org/maven2/']]),
+    );
+    expect(labels['distribution:url']).toBe(expectedUrl);
+  });
+
+  it('returns no label when the recorded repo id is not in the URL map', async () => {
+    const labels = await readRemoteRepositoryLabel(node, repoRoot, new Map());
+    expect(labels).toEqual({});
+  });
+
+  it('returns no label when there is no _remote.repositories file', async () => {
+    const otherDepId = 'com.example:bar:jar:2.0';
+    const otherNode: M2Node = {
+      nodeId: otherDepId,
+      artifactPath: dependencyIdToArtifactPath(otherDepId, repoRoot),
+    };
+    const labels = await readRemoteRepositoryLabel(
+      otherNode,
+      repoRoot,
+      new Map([['central', 'https://repo.maven.apache.org/maven2']]),
+    );
+    expect(labels).toEqual({});
+  });
+});

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -12,12 +12,8 @@ import type { M2Node } from '../../../lib/parse/m2-batch';
 // Build a repo→entry map from ordered [id, url] pairs, stamping rank by position
 // so the first pair is the highest priority — mirroring how fetchRepositoryUrlMap
 // ranks dependency:list-repositories output.
-function rankedMap(
-  ...pairs: [string, string][]
-): Map<string, RepositoryEntry> {
-  return new Map(
-    pairs.map(([id, url], rank) => [id, { url, rank }]),
-  );
+function rankedMap(...pairs: [string, string][]): Map<string, RepositoryEntry> {
+  return new Map(pairs.map(([id, url], rank) => [id, { url, rank }]));
 }
 
 // Resolve the label for a single node through the production path

--- a/tests/jest/system/m2-component-metadata-e2e.spec.ts
+++ b/tests/jest/system/m2-component-metadata-e2e.spec.ts
@@ -12,11 +12,12 @@ const testProjectPath = path.join(fixturesPath, 'test-project');
 // through a shell — mirror lib/sub-process.ts, which sets `shell: true` there.
 const isWindows = /^win/.test(os.platform());
 
-// Hash labels are read from the JAR's companion checksum files in the local
-// Maven repository. A bare `dependency:tree` resolution does not necessarily
-// download the JAR bytes (and therefore the `.jar.sha1`/`.md5` companions), so
-// resolve the fixture's artifacts into `~/.m2` up front — CI starts with an
-// empty repository.
+// Component metadata (hash + distribution:url labels) is read from files in the
+// local Maven repository — the JAR's companion checksums and the
+// `_remote.repositories` file Maven writes alongside a downloaded artifact. A
+// bare `dependency:tree` resolution does not necessarily download the JAR bytes
+// (and therefore those companion files), so resolve the fixture's artifacts into
+// `~/.m2` up front — CI starts with an empty repository.
 beforeAll(() => {
   execFileSync('mvn', ['clean', 'install', '-DskipTests'], {
     cwd: testProjectPath,
@@ -31,8 +32,8 @@ function hashLabelKeys(labels?: {
   return Object.keys(labels ?? {}).filter((key) => key.startsWith('hash:'));
 }
 
-test('hash labels disabled vs enabled comparison', async () => {
-  // Hashes disabled (default).
+test('component metadata disabled vs enabled comparison', async () => {
+  // Disabled (default).
   const resultDisabled = await inspect(
     '.',
     path.join(testProjectPath, 'pom.xml'),
@@ -46,7 +47,7 @@ test('hash labels disabled vs enabled comparison', async () => {
     throw new Error('expected multi inspect result for disabled case');
   }
 
-  // Hashes enabled.
+  // Enabled.
   const resultEnabled = await inspect(
     '.',
     path.join(testProjectPath, 'pom.xml'),
@@ -68,9 +69,10 @@ test('hash labels disabled vs enabled comparison', async () => {
     disabledGraph.graph.nodes.length,
   );
 
-  // Disabled: no node carries a hash:* label.
+  // Disabled: no node carries a hash:* or distribution:url label.
   for (const node of disabledGraph.graph.nodes) {
     expect(hashLabelKeys(node.info?.labels)).toHaveLength(0);
+    expect(node.info?.labels?.['distribution:url']).toBeUndefined();
   }
 
   // Enabled: the axis dependency was resolved into the local Maven repository,
@@ -95,17 +97,29 @@ test('hash labels disabled vs enabled comparison', async () => {
     expect(axisLabels['hash:sha-512']).toMatch(/^[0-9a-f]{128}$/);
   }
 
-  // At least one resolved dependency carries hash labels end-to-end.
+  // Enabled: the axis dependency was downloaded from Maven Central, so its
+  // `_remote.repositories` file records `central` and `dependency:list-repositories`
+  // reports central's URL — together they resolve the full artifact URL.
+  expect(axisLabels['distribution:url']).toBe(
+    'https://repo.maven.apache.org/maven2/axis/axis/1.4/axis-1.4.jar',
+  );
+
+  // At least one resolved dependency carries each label kind end-to-end.
   const nodesWithHashes = enabledGraph.graph.nodes.filter(
     (node) => hashLabelKeys(node.info?.labels).length > 0,
   );
   expect(nodesWithHashes.length).toBeGreaterThan(0);
+
+  const nodesWithDistributionUrl = enabledGraph.graph.nodes.filter(
+    (node) => node.info?.labels?.['distribution:url'],
+  );
+  expect(nodesWithDistributionUrl.length).toBeGreaterThan(0);
 });
 
-test('hash labels graceful failure with nonexistent repository', async () => {
-  // Point the hash reader at a repository that does not exist. Maven still
-  // resolves the tree, but no companion files can be read, so inspect succeeds
-  // with no hash labels rather than throwing.
+test('component metadata graceful failure with nonexistent repository', async () => {
+  // Point the readers at a repository that does not exist. Maven still resolves
+  // the tree, but no companion or _remote.repositories files can be read, so
+  // inspect succeeds with no hash or distribution:url labels rather than throwing.
   const result = await inspect('.', path.join(testProjectPath, 'pom.xml'), {
     dev: false,
     includeComponentMetadata: true,
@@ -118,5 +132,6 @@ test('hash labels graceful failure with nonexistent repository', async () => {
 
   for (const node of result.scannedProjects[0].depGraph!.toJSON().graph.nodes) {
     expect(hashLabelKeys(node.info?.labels)).toHaveLength(0);
+    expect(node.info?.labels?.['distribution:url']).toBeUndefined();
   }
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

### What does this PR do?

Extends includeComponentMetadata to also emit a distribution:url label on each Maven node, recording the remote URL the artifact was originally resolved from. The URL is built from two sources in the local `~/.m2` repository:

- `_remote.repositories` (written by Maven next to each installed artifact) — gives the repository id the artifact came from (e.g. central).
- `mvn dependency:list-repositories` — maps that repository id to its base URL.

The artifact's repo-relative path is appended to the base URL to form the full distribution:url, which flows through to the CycloneDX ExternalReferences (distribution type).

Key behaviours:
- Resolved once per inspect: the node set and each node's `.m2` artifact path are computed a single time and shared between the hash-label and distribution-url passes (`lib/parse/m2-batch.ts`).
- The hash-label reads run concurrently with the `dependency:list-repositories` subprocess rather than serially.
- Graceful degradation throughout — a missing file, an unknown repo id, or a failed Maven invocation simply means no label for that artifact, never an error.

### Where should the reviewer start?

`lib/parse/m2-remote-repositories.ts` (the new parsing/URL logic) and the orchestration in `lib/index.ts` (inspect, the includeComponentMetadata block). `lib/parse/m2-batch.ts` is the small shared scaffold both label passes now use.

### How should this be manually tested?

Against a Maven project whose dependencies are already resolved into `~/.m2` (so the `_remote.repositories` files exist):
```
# SBOM path exercises includeComponentMetadata + --print-graph
./bin/snyk sbom --format=cyclonedx1.4+json --file=pom.xml /path/to/maven-project \
  | jq '.components[].externalReferences'
```
Confirm distribution-type references appear with sane URLs. Worth spot-checking:
- Off-cwd / monorepo pom (`--file=subdir/pom.xml` from a different working dir) — labels should still resolve (the `dependency:list-repositories` call is now scoped with cwd/`--file`, mirroring the dependency-tree pipeline).
- A mirror/settings.xml repo URL ending in / — the emitted URL must not contain a // (trailing-slash normalisation).
- Aggregate project (`--maven-aggregate-project`) — repositories are unioned across modules.

Direct-plugin alternative:
```
DEBUG=snyk-mvn-plugin node -e "require('./dist').inspect('/path/to/project','pom.xml',{includeComponentMetadata:true}).then(r=>console.log(JSON.stringify(r,null,2)))"
```
Then grep for distribution:url.

Automated coverage: npm run test:functional (see tests/jest/functional/m2-remote-repositories.spec.ts and m2-hash-labels.spec.ts).

### Any background context you want to provide?

Builds on the existing `includeComponentMetadata` hash-label work and reuses the same .m2 access path. Notable correctness fixes folded in during review: the feature is gated solely on `includeComponentMetadata` (no separate flag); `dependency:list-repositories` runs with `--batch-mode` and proper cwd/`--file` targeting; the `_remote.repositories` read is byte-bounded (64 KiB) like the sibling hash-labels module; and the repo-URL join is trailing-slash-normalised.

### What are the relevant tickets?

- [CMPA-604](https://snyksec.atlassian.net/browse/CMPA-604)

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling component metadata triggers an extra Maven subprocess and changes SBOM/CycloneDX external-reference output; failures degrade to missing labels rather than breaking inspect.
> 
> **Overview**
> With **`includeComponentMetadata`**, Maven inspect now also attaches **`distribution:url`** on dependency-graph nodes, in addition to existing **`hash:*`** labels from `.m2` companion checksums.
> 
> **Distribution URLs** come from each artifact’s **`_remote.repositories`** file (repo id Maven recorded at install) joined to base URLs from a pinned **`dependency:list-repositories`** run. The full URL is repo base + path under the local repository. Mirror ids are mapped separately so mirrored caches still resolve; multiple recorded ids pick the highest-priority repo by **`list-repositories`** order; missing files, unknown ids, or a failed Maven goal omit the label only.
> 
> **Orchestration** resolves `.m2` node paths once via **`m2-batch`**, runs hash reads and **`_remote.repositories`** I/O **in parallel** with **`list-repositories`**, and merges both label maps in **`buildDepGraph`**. Hash labeling is refactored to the same batch scaffold (**`readM2HashLabels(artifactPath)`** instead of **`buildM2HashLabelsMap`**). **`explicitPluginVersion`** is exposed from the Maven executor so the extra goal uses the same dependency-plugin version as the tree pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1cb93e2b1feb05fb1d227a686d0722caf5e1306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->