### PR TITLE
fix: strip embedded credentials from distribution:url labels [CMPA-604]

### DIFF
--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -274,6 +274,34 @@ export async function readRemoteRepositoryIds(node: M2Node): Promise<string[]> {
 }
 
 /**
+ * Strip embedded basic-auth userinfo (scheme://user:pass@host) from a
+ * repository URL so credentials configured on a private Maven repository
+ * (settings.xml/mirror URLs like `https://user:secret@example.com/maven2`)
+ * never leak into the distribution:url label or downstream SBOM
+ * externalReferences. Mirrors the URL-class-based stripping
+ * nodejs-lockfile-parser applies to npm/yarn resolved URLs.
+ *
+ * Falls back to the raw URL if it isn't a parseable absolute URL — repo URLs
+ * handled here always come from Maven's own dependency:list-repositories
+ * output, so this should not happen in practice.
+ */
+function stripUrlCredentials(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+
+  if (url.username || url.password) {
+    url.username = '';
+    url.password = '';
+  }
+
+  return url.toString();
+}
+
+/**
  * Join an artifact's recorded repository IDs against the fetched repo→entry map
  * to construct its distribution:url label. Pure in-memory work — no I/O.
  *
@@ -319,7 +347,8 @@ export function buildDistributionUrlLabel(
   const relativePath = path
     .relative(repositoryPath, node.artifactPath)
     .replace(/\\/g, '/');
-  const fullUrl = `${best.url.replace(/\/+$/, '')}/${relativePath}`;
+  const sanitizedUrl = stripUrlCredentials(best.url);
+  const fullUrl = `${sanitizedUrl.replace(/\/+$/, '')}/${relativePath}`;
   debug(`Resolved distribution URL for ${node.nodeId}: ${fullUrl}`);
   return { 'distribution:url': fullUrl };
 }

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -81,6 +81,23 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     expect(labels['distribution:url']).toBe(expectedUrl);
   });
 
+  it('strips embedded basic-auth credentials from the repo URL', async () => {
+    // A repository configured with credentials in the URL itself (rather than
+    // a settings.xml <server> block), e.g. <url>https://user:secret@example.com/maven2</url>.
+    // Maven's dependency:list-repositories prints this verbatim, so the fetched
+    // repo map can legitimately carry userinfo — it must never reach the label.
+    const labels = await labelFor(
+      node,
+      repoRoot,
+      rankedMap(['central', 'https://user:secret@example.com/maven2']),
+    );
+    expect(labels['distribution:url']).toBe(
+      'https://example.com/maven2/com/example/foo/1.0/foo-1.0.jar',
+    );
+    expect(labels['distribution:url']).not.toContain('user');
+    expect(labels['distribution:url']).not.toContain('secret');
+  });
+
   it('returns no label when the recorded repo id is not in the URL map', async () => {
     const labels = await labelFor(node, repoRoot, new Map());
     expect(labels).toEqual({});


### PR DESCRIPTION
## What does this PR do?

Follow-up to #224. A Maven repository can be configured with basic-auth
credentials embedded directly in its URL (`https://user:secret@example.com/maven2`),
rather than via a `settings.xml` `<server>` block. `mvn dependency:list-repositories`
prints that URL verbatim, and `fetchRepositoryUrlMap`/`buildDistributionUrlLabel`
joined it straight into the `distribution:url` label with no stripping — meaning
those credentials would flow into the dep-graph label and downstream CycloneDX
`externalReferences`.

Adds `stripUrlCredentials`, which parses the URL with the `URL` class and clears
`.username`/`.password` before the label is built — mirroring the same
credential-stripping guard `nodejs-lockfile-parser`'s `distributionUrlLabel`
already applies to npm/yarn resolved URLs. Uses the URL class rather than
regex/string manipulation for correctness (matching `@`/userinfo in a URL by
regex is error-prone).

## What are the relevant tickets?

[CMPA-604](https://snyksec.atlassian.net/browse/CMPA-604)

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, defensive change on label emission only; reduces credential exposure with a fallback for unparseable URLs and new test coverage.
> 
> **Overview**
> Prevents **basic-auth userinfo** in private Maven repository URLs from appearing in `distribution:url` dep-graph labels and downstream CycloneDX `externalReferences`.
> 
> Adds **`stripUrlCredentials`**, which parses repo URLs with the `URL` API and clears `username`/`password` before `buildDistributionUrlLabel` assembles the artifact URL (same idea as npm/yarn resolved-URL handling elsewhere). Unparseable URLs are left unchanged.
> 
> A functional test asserts credentialed repo map entries (`https://user:secret@example.com/maven2`) produce a clean label with no `user` or `secret`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f60b6254ee9251acf6818b6774f51b210c8d733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->