### PR TITLE
fix: harden distribution:url credential handling and repository path resolution

### DIFF
--- a/lib/fingerprint.ts
+++ b/lib/fingerprint.ts
@@ -50,13 +50,48 @@ export async function getMavenRepositoryPath(
 }
 
 /**
- * Convert dependency ID to the expected artifact file path in Maven repository
+ * Convert dependency ID to the expected artifact file path in the Maven
+ * repository, or `undefined` if the coordinate would resolve OUTSIDE the
+ * repository root.
+ *
+ * A dependency coordinate is untrusted input: node ids come from `mvn
+ * dependency:tree` output, whose root node is the scanned project's own
+ * groupId:artifactId:type:version straight from its pom.xml. Maven accepts a
+ * version like `../../../../etc/passwd` (it only warns), so a crafted segment
+ * can drive `path.join` out of the repository and turn the downstream `stat` /
+ * read / hash into an arbitrary-file existence and content oracle. We therefore
+ * reject any coordinate whose resolved path escapes `repositoryPath`.
+ *
+ * The containment check is relative to whatever `repositoryPath` was resolved
+ * (the default `~/.m2/repository`, or a user-chosen `-Dmaven.repo.local=...` /
+ * `mavenRepository`), so relocating the local repo — a trusted, deliberate
+ * choice — keeps working; only coordinate-driven escapes out of the chosen base
+ * are blocked.
  */
 export function dependencyIdToArtifactPath(
   dependencyId: string,
   repositoryPath: string,
-): string {
+): string | undefined {
   const dep = parseDependency(dependencyId);
+
+  // Segment guard: a well-formed Maven coordinate segment is never a path
+  // separator or a `..` component. Reject those before building the path — `..`
+  // would climb out of the repository, and an embedded separator would let a
+  // coordinate inject arbitrary path structure. This matters even when the
+  // containment check below passes: if repositoryPath is a broad root (e.g. a
+  // custom `-Dmaven.repo.local=/`), containment is vacuous and segment shape is
+  // the only thing keeping a coordinate on the expected group/artifact/version
+  // layout. groupId maps its dots to separators by design, so it is validated
+  // for raw separators only, not for the resulting path components.
+  if (
+    hasUnsafeSegment(dep.artifactId) ||
+    hasUnsafeSegment(dep.version) ||
+    hasUnsafeSegment(dep.type) ||
+    (dep.classifier !== undefined && hasUnsafeSegment(dep.classifier)) ||
+    /[/\\]/.test(dep.groupId)
+  ) {
+    return undefined;
+  }
 
   // Convert groupId dots to path separators
   const groupPath = dep.groupId.replace(/\./g, path.sep);
@@ -75,7 +110,28 @@ export function dependencyIdToArtifactPath(
     artifactFileName,
   );
 
+  // Containment backstop: reject anything that still resolves outside
+  // repositoryPath. Relative to whatever base was resolved, so a deliberately
+  // relocated local repo keeps working while coordinate-driven escapes do not.
+  const relativeToRepo = path.relative(
+    path.resolve(repositoryPath),
+    path.resolve(artifactPath),
+  );
+  if (relativeToRepo.startsWith('..') || path.isAbsolute(relativeToRepo)) {
+    return undefined;
+  }
+
   return artifactPath;
+}
+
+/**
+ * True if a Maven coordinate segment contains a path separator or is a `..`
+ * component — neither of which occurs in a legitimate groupId label,
+ * artifactId, version, classifier or type, and both of which can steer the
+ * constructed artifact path off the expected repository layout.
+ */
+function hasUnsafeSegment(segment: string): boolean {
+  return segment === '..' || /[/\\]/.test(segment);
 }
 
 /**
@@ -134,15 +190,25 @@ async function processSingleDependency(
 ): Promise<FingerprintData> {
   const startTime = performance.now();
 
-  try {
-    const artifactPath = dependencyIdToArtifactPath(
-      dependencyId,
-      repositoryPath,
-    );
-    const { exists, size } = await checkArtifactExists(artifactPath);
+  const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
+  if (artifactPath === undefined) {
+    // The coordinate resolves outside the repository (crafted traversal or an
+    // otherwise malformed segment); refuse to touch the filesystem at all.
+    return {
+      hash: '',
+      algorithm,
+      filePath: '',
+      fileSize: 0,
+      processingTime: performance.now() - startTime,
+      error: 'Artifact path escapes repository',
+    };
+  }
 
-    // Sanitize the artifact path to show only the relative path within the repository
-    const sanitizedPath = sanitizeArtifactPath(artifactPath, repositoryPath);
+  // Sanitize the artifact path to show only the relative path within the repository
+  const sanitizedPath = sanitizeArtifactPath(artifactPath, repositoryPath);
+
+  try {
+    const { exists, size } = await checkArtifactExists(artifactPath);
 
     if (!exists) {
       const endTime = performance.now();
@@ -168,11 +234,6 @@ async function processSingleDependency(
     };
   } catch (error) {
     const endTime = performance.now();
-    const artifactPath = dependencyIdToArtifactPath(
-      dependencyId,
-      repositoryPath,
-    );
-    const sanitizedPath = sanitizeArtifactPath(artifactPath, repositoryPath);
 
     return {
       hash: '',

--- a/lib/parse/m2-batch.ts
+++ b/lib/parse/m2-batch.ts
@@ -32,10 +32,17 @@ export function collectM2Nodes(
   for (const graph of mavenGraphs) {
     Object.keys(graph.nodes).forEach((nodeId) => nodeIds.add(nodeId));
   }
-  return Array.from(nodeIds).map((nodeId) => ({
-    nodeId,
-    artifactPath: dependencyIdToArtifactPath(nodeId, repositoryPath),
-  }));
+  const nodes: M2Node[] = [];
+  for (const nodeId of nodeIds) {
+    const artifactPath = dependencyIdToArtifactPath(nodeId, repositoryPath);
+    // Drop nodes whose coordinate resolves outside the repository — the same
+    // containment guard the fingerprint pass applies, so a crafted coordinate
+    // can never drive the hash-label or distribution-url reads out of the repo.
+    if (artifactPath !== undefined) {
+      nodes.push({ nodeId, artifactPath });
+    }
+  }
+  return nodes;
 }
 
 /**

--- a/lib/parse/m2-remote-repositories.ts
+++ b/lib/parse/m2-remote-repositories.ts
@@ -122,11 +122,24 @@ export async function fetchRepositoryUrlMap(
     // stamp it with the rank of that first occurrence — its position in the
     // priority-ordered output. `result.size` is the next free rank because we
     // only ever insert new ids here.
-    const addRepo = (id: string, url: string): void => {
-      if (!result.has(id)) {
-        result.set(id, { url, rank: result.size });
-        debug(`Found repository (rank ${result.size - 1}): ${id} -> ${url}`);
+    //
+    // This is the one trust boundary for repo URLs: Maven output can carry
+    // embedded basic-auth userinfo, so we strip credentials here, before the URL
+    // enters the map or any log line. Downstream readers (the label builder)
+    // then treat map URLs as already-sanitised and never re-strip. An
+    // unparseable URL (e.g. a port outside 0-65535) can't be sanitised and is
+    // unusable as a distribution URL, so the repo is dropped rather than stored.
+    const addRepo = (id: string, rawUrl: string): void => {
+      if (result.has(id)) {
+        return;
       }
+      const url = stripUrlCredentials(rawUrl);
+      if (url === undefined) {
+        debug(`Skipping repository ${id}: URL is not parseable`);
+        return;
+      }
+      result.set(id, { url, rank: result.size });
+      debug(`Found repository (rank ${result.size - 1}): ${id} -> ${url}`);
     };
 
     for (const line of lines) {
@@ -281,16 +294,20 @@ export async function readRemoteRepositoryIds(node: M2Node): Promise<string[]> {
  * externalReferences. Mirrors the URL-class-based stripping
  * nodejs-lockfile-parser applies to npm/yarn resolved URLs.
  *
- * Falls back to the raw URL if it isn't a parseable absolute URL — repo URLs
- * handled here always come from Maven's own dependency:list-repositories
- * output, so this should not happen in practice.
+ * `new URL()` rejects some inputs before we can clear their userinfo — most
+ * notably a port outside 0-65535 (e.g. `https://user:pw@host:99999/maven2`),
+ * which throws on construction. Returning the raw URL in that case would leak
+ * the very credentials this function exists to remove, so an unparseable URL
+ * yields `undefined` — the caller (fetchRepositoryUrlMap) drops the repo rather
+ * than store unsanitised userinfo. An unparseable repo URL is unusable as a
+ * distribution URL anyway.
  */
-function stripUrlCredentials(rawUrl: string): string {
+function stripUrlCredentials(rawUrl: string): string | undefined {
   let url: URL;
   try {
     url = new URL(rawUrl);
   } catch {
-    return rawUrl;
+    return undefined;
   }
 
   if (url.username || url.password) {
@@ -347,8 +364,9 @@ export function buildDistributionUrlLabel(
   const relativePath = path
     .relative(repositoryPath, node.artifactPath)
     .replace(/\\/g, '/');
-  const sanitizedUrl = stripUrlCredentials(best.url);
-  const fullUrl = `${sanitizedUrl.replace(/\/+$/, '')}/${relativePath}`;
+  // best.url was already credential-stripped and validated at ingest
+  // (fetchRepositoryUrlMap), so use it directly — no re-sanitisation needed.
+  const fullUrl = `${best.url.replace(/\/+$/, '')}/${relativePath}`;
   debug(`Resolved distribution URL for ${node.nodeId}: ${fullUrl}`);
   return { 'distribution:url': fullUrl };
 }

--- a/tests/jest/functional/fingerprint.spec.ts
+++ b/tests/jest/functional/fingerprint.spec.ts
@@ -75,6 +75,52 @@ describe('Fingerprint Module Unit Tests', () => {
       const result = dependencyIdToArtifactPath(dependencyId, testRepoPath);
       expect(result).toBe(expected);
     });
+
+    it('returns undefined for a version that traverses out of the repository', () => {
+      // A malicious pom.xml can set the project version to a traversal string;
+      // Maven only warns and still emits it as the root dependency:tree node.
+      // The resulting path must not be allowed to escape the repository, or the
+      // downstream stat/hash becomes an arbitrary-file oracle.
+      const dependencyId =
+        'com.evil:evil:jar:../../../../../../../../etc/passwd';
+      expect(
+        dependencyIdToArtifactPath(dependencyId, testRepoPath),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when a coordinate segment contains a path separator', () => {
+      // A separator in artifactId/version/type is never valid in a real Maven
+      // coordinate; rejecting it keeps the on-disk layout rigid even when the
+      // repository base is broad (e.g. a custom -Dmaven.repo.local=/).
+      expect(
+        dependencyIdToArtifactPath('com.evil:a/b:jar:1.0', testRepoPath),
+      ).toBeUndefined();
+      expect(
+        dependencyIdToArtifactPath('com.evil:evil:jar:1.0/../..', testRepoPath),
+      ).toBeUndefined();
+      expect(
+        dependencyIdToArtifactPath('com.evil:evil:ja\\r:1.0', testRepoPath),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when a segment is a bare parent-directory component', () => {
+      expect(
+        dependencyIdToArtifactPath('com.evil:evil:jar:..', testRepoPath),
+      ).toBeUndefined();
+    });
+
+    it('still resolves a legitimate coordinate under a relocated repository base', () => {
+      // Relocating the local repo (a trusted -Dmaven.repo.local choice) must
+      // keep working: containment is relative to that base, not a hardcoded .m2.
+      const customBase = '/opt/custom-m2';
+      const result = dependencyIdToArtifactPath(
+        'com.example:app:jar:1.0.0',
+        customBase,
+      );
+      expect(result).toBe(
+        path.join(customBase, 'com/example/app/1.0.0/app-1.0.0.jar'),
+      );
+    });
   });
 
   describe('createMavenPurlWithChecksum', () => {

--- a/tests/jest/functional/m2-hash-labels.spec.ts
+++ b/tests/jest/functional/m2-hash-labels.spec.ts
@@ -10,6 +10,17 @@ import { collectM2Nodes, buildLabelMap } from '../../../lib/parse/m2-batch';
 import { dependencyIdToArtifactPath } from '../../../lib/fingerprint';
 import type { MavenGraph, ParseContext } from '../../../lib/parse/types';
 
+// dependencyIdToArtifactPath returns undefined only for coordinates that escape
+// the repository; every coordinate in these tests is well-formed, so assert a
+// path is produced and keep the call sites typed as string.
+function artifactPathFor(dependencyId: string, repositoryPath: string): string {
+  const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
+  if (artifactPath === undefined) {
+    throw new Error(`expected a path for ${dependencyId}`);
+  }
+  return artifactPath;
+}
+
 // Helper: write a fake artifact JAR plus the three companion files Maven
 // would have written when it pulled the artifact from a registry. The JAR
 // content is arbitrary (we never read it); the companion files contain real
@@ -101,7 +112,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
   describe('readM2HashLabels', () => {
     it('reads md5/sha-1/sha-256 from companion files', async () => {
       const labels = await readM2HashLabels(
-        dependencyIdToArtifactPath(
+        artifactPathFor(
           'com.google.guava:guava:jar:32.1.3-jre',
           repoRoot,
         ),
@@ -113,7 +124,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
 
     it('returns an empty object when the artifact is not in the repository', async () => {
       const labels = await readM2HashLabels(
-        dependencyIdToArtifactPath(
+        artifactPathFor(
           'org.unknown:nothing-here:jar:0.0.0',
           repoRoot,
         ),
@@ -134,7 +145,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       fs.unlinkSync(`${jarPath}.sha256`);
 
       const labels = await readM2HashLabels(
-        dependencyIdToArtifactPath('com.example:no-sha256:jar:1.0.0', repoRoot),
+        artifactPathFor('com.example:no-sha256:jar:1.0.0', repoRoot),
       );
       expect(Object.keys(labels).sort()).toEqual(['hash:md5', 'hash:sha-1']);
     });
@@ -156,7 +167,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       );
 
       const labels = await readM2HashLabels(
-        dependencyIdToArtifactPath(
+        artifactPathFor(
           'com.example:html-sha256:jar:1.0.0',
           repoRoot,
         ),
@@ -177,7 +188,7 @@ describe('Maven hash:<alg> label emission from .m2 companion files', () => {
       fs.writeFileSync(`${jarPath}.sha256`, 'deadbeef\n');
 
       const labels = await readM2HashLabels(
-        dependencyIdToArtifactPath(
+        artifactPathFor(
           'com.example:short-sha256:jar:1.0.0',
           repoRoot,
         ),

--- a/tests/jest/functional/m2-remote-repositories-parse.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories-parse.spec.ts
@@ -135,6 +135,41 @@ describe('fetchRepositoryUrlMap output parsing', () => {
     expect(map.size).toBe(1);
   });
 
+  it('strips embedded basic-auth credentials from repository urls at ingest', async () => {
+    // A repository configured with credentials in the URL itself (rather than a
+    // settings.xml <server> block), e.g. https://user:secret@example.com/maven2.
+    // dependency:list-repositories prints it verbatim, so the userinfo must be
+    // stripped here — the map, logs and downstream labels must never carry it.
+    mockedExecute.mockResolvedValue(
+      `[INFO] Project remote repositories used by this build:
+ * central (https://user:secret@example.com/maven2, default, releases)
+`,
+    );
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    const entry = map.get('central');
+    expect(entry?.url).toBe('https://example.com/maven2');
+    expect(entry?.url).not.toContain('user');
+    expect(entry?.url).not.toContain('secret');
+  });
+
+  it('drops a repository whose url is not parseable (port out of range)', async () => {
+    // A port above 65535 makes `new URL()` throw on construction, so the
+    // credentials can't be stripped. Rather than store the raw URL (leaking the
+    // userinfo), the repo is omitted from the map entirely.
+    mockedExecute.mockResolvedValue(
+      `[INFO] Project remote repositories used by this build:
+ * central (https://user:secret@example.com:99999/maven2, default, releases)
+`,
+    );
+
+    const map = await fetchRepositoryUrlMap(context, false);
+
+    expect(map.has('central')).toBe(false);
+    expect(map.size).toBe(0);
+  });
+
   it('returns an empty map when no repository lines are present', async () => {
     mockedExecute.mockResolvedValue(
       `[INFO] Project remote repositories used by this build:

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -81,23 +81,6 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     expect(labels['distribution:url']).toBe(expectedUrl);
   });
 
-  it('strips embedded basic-auth credentials from the repo URL', async () => {
-    // A repository configured with credentials in the URL itself (rather than
-    // a settings.xml <server> block), e.g. <url>https://user:secret@example.com/maven2</url>.
-    // Maven's dependency:list-repositories prints this verbatim, so the fetched
-    // repo map can legitimately carry userinfo — it must never reach the label.
-    const labels = await labelFor(
-      node,
-      repoRoot,
-      rankedMap(['central', 'https://user:secret@example.com/maven2']),
-    );
-    expect(labels['distribution:url']).toBe(
-      'https://example.com/maven2/com/example/foo/1.0/foo-1.0.jar',
-    );
-    expect(labels['distribution:url']).not.toContain('user');
-    expect(labels['distribution:url']).not.toContain('secret');
-  });
-
   it('returns no label when the recorded repo id is not in the URL map', async () => {
     const labels = await labelFor(node, repoRoot, new Map());
     expect(labels).toEqual({});

--- a/tests/jest/functional/m2-remote-repositories.spec.ts
+++ b/tests/jest/functional/m2-remote-repositories.spec.ts
@@ -16,6 +16,17 @@ function rankedMap(...pairs: [string, string][]): Map<string, RepositoryEntry> {
   return new Map(pairs.map(([id, url], rank) => [id, { url, rank }]));
 }
 
+// dependencyIdToArtifactPath returns undefined only for coordinates that escape
+// the repository; every coordinate in these tests is well-formed, so assert a
+// path is produced and keep the call sites typed as string.
+function artifactPathFor(dependencyId: string, repositoryPath: string): string {
+  const artifactPath = dependencyIdToArtifactPath(dependencyId, repositoryPath);
+  if (artifactPath === undefined) {
+    throw new Error(`expected a path for ${dependencyId}`);
+  }
+  return artifactPath;
+}
+
 // Resolve the label for a single node through the production path
 // (buildRemoteRepositoryLabelMap), returning {} when no label is emitted. Keeps
 // the per-node assertions below exercising the code that actually ships.
@@ -45,7 +56,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
 
     // Stand up a fake installed artifact plus the _remote.repositories file
     // Maven writes alongside it, recording the repo the jar came from.
-    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const artifactPath = artifactPathFor(depId, repoRoot);
     const dir = path.dirname(artifactPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(artifactPath, 'fake jar contents');
@@ -90,7 +101,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     const otherDepId = 'com.example:bar:jar:2.0';
     const otherNode: M2Node = {
       nodeId: otherDepId,
-      artifactPath: dependencyIdToArtifactPath(otherDepId, repoRoot),
+      artifactPath: artifactPathFor(otherDepId, repoRoot),
     };
     const labels = await labelFor(
       otherNode,
@@ -102,7 +113,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
 
   it('ignores a co-located -sources.jar recorded against a different repo', async () => {
     const depId = 'com.example:classified:jar:1.0';
-    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const artifactPath = artifactPathFor(depId, repoRoot);
     const dir = path.dirname(artifactPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(artifactPath, 'fake jar contents');
@@ -128,7 +139,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
 
   it('emits no label when the artifact was installed locally (empty repo id)', async () => {
     const depId = 'com.example:local:jar:1.0';
-    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const artifactPath = artifactPathFor(depId, repoRoot);
     const dir = path.dirname(artifactPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(artifactPath, 'fake jar contents');
@@ -152,7 +163,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     // jboss above central, so the label must resolve to jboss (rank 0), not
     // whichever id happens to appear first in the file.
     const depId = 'com.example:multi:jar:1.0';
-    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const artifactPath = artifactPathFor(depId, repoRoot);
     const dir = path.dirname(artifactPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(artifactPath, 'fake jar contents');
@@ -181,7 +192,7 @@ describe('distribution:url label emission from .m2 _remote.repositories files', 
     // (jboss missing, e.g. cached by another project). Rather than lose the
     // label, we credit the known lower-priority repo.
     const depId = 'com.example:partial:jar:1.0';
-    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const artifactPath = artifactPathFor(depId, repoRoot);
     const dir = path.dirname(artifactPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(artifactPath, 'fake jar contents');
@@ -210,7 +221,7 @@ describe('buildRemoteRepositoryLabelMap two-phase build', () => {
   const urlMap = rankedMap(['central', 'https://repo.maven.apache.org/maven2']);
 
   function install(depId: string, repoId?: string): M2Node {
-    const artifactPath = dependencyIdToArtifactPath(depId, repoRoot);
+    const artifactPath = artifactPathFor(depId, repoRoot);
     const dir = path.dirname(artifactPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(artifactPath, 'fake jar contents');


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Two related security hardening fixes in the component-metadata / provenance code paths, surfaced while investigating cli#7019 and a follow-up whole-library security review.

**1. Potential credential leak from repo URLs (`lib/parse/m2-remote-repositories.ts`)** — follow-up to #228. Two residual ways embedded basic-auth credentials could still leak from a private Maven repo URL:
- `stripUrlCredentials` returned the *raw* URL whenever `new URL()` threw — most notably for a port outside `0–65535` (e.g. `https://user:pw@host:99999/maven2`) — so a malformed URL bypassed stripping and the credentials reached the label.
- `fetchRepositoryUrlMap` logged each repo URL verbatim (`debug`) *before* sanitisation.

Fix: sanitise once at the single trust boundary (ingest in `fetchRepositoryUrlMap`), before the URL enters the map or any log. Unparseable URLs are dropped; downstream readers trust the map and no longer re-strip.

**2. Path traversal / arbitrary-file read via dependency coordinate (`lib/fingerprint.ts`, `lib/parse/m2-batch.ts`)** — `dependencyIdToArtifactPath` built `path.join(repositoryPath, group, artifactId, version, filename)` with no containment check. Coordinate segments are untrusted (the root `dependency:tree` node is the scanned project's own `pom.xml` `groupId:artifactId:type:version`), and Maven only *warns* about an illegal version like `../../../../etc/passwd` while still emitting it. So a crafted version could escape `~/.m2/repository`; the escaped path would then be `stat`-ed, read and SHA-hashed, and the hash/size surfaced in the emitted dep-graph PURL — an arbitrary-file existence + content oracle. Note the escape is a *read*: the dependency-plugin artifacts are still written to the normal writable `.m2`, while the crafted coordinate only reads the escaped path, so this is exploitable against a completely ordinary setup. **Verified end-to-end against Maven 3.9.11.**

Fix: `dependencyIdToArtifactPath` now returns `string | undefined`, rejecting coordinates that resolve outside the repository via (a) a segment guard (no path separators or bare `..` in artifactId/version/classifier/type; no raw separator in groupId) and (b) a containment backstop relative to the resolved base. The containment check is relative to whatever base was resolved, so a legitimately relocated local repo keeps working. Consumers drop escaping nodes gracefully (no filesystem access).

#### Where should the reviewer start?

- `lib/parse/m2-remote-repositories.ts` — the `addRepo` closure (sole sanitisation point) and `stripUrlCredentials`.
- `lib/fingerprint.ts` — `dependencyIdToArtifactPath` (segment guard + containment backstop) and `processSingleDependency` (graceful skip).

#### How should this be manually tested?

`npx jest tests/jest/functional` — 134 tests pass, including new cases for credential stripping at ingest, dropping unparseable-URL repos, coordinate traversal rejection, separator-injection rejection, and legitimate relocated-repo resolution.

Repro of the traversal (pre-fix) on Maven 3.9.11: a project `pom.xml` with `<version>../../../../../../../../tmp/pwned</version>` yields `BUILD SUCCESS` and a root dot node `com.evil:evil:jar:../../../../../../../../tmp/pwned`, which resolved to `/tmp/pwned.jar`, escaping `.m2`.

#### Any background context you want to provide?

Follow-up to #228. The path-traversal is pre-existing (in the `includeProvenance` / `includeComponentMetadata` fingerprinting code, not introduced by the credential work), but is closely related and bundled here.

Residual / scope note: the segment guard additionally blocks separator-injection under a deliberately broad repository base. The base (`getMavenRepositoryPath`) is resolved only from the `mavenRepository` provided-path option or from a bare `mvn help:evaluate -Dexpression=settings.localRepository` call — the latter does **not** forward user `-D` args, so a `-Dmaven.repo.local=…` passed via `--` reaches `dependency:tree`/`list-repositories` but does not set our base; the only way the base becomes broad (e.g. `/`) is the trusted `mavenRepository` option. The only remaining theoretical case — a coordinate mapping to a file that happens to sit at Maven-layout depth under such a broad base — is not meaningfully exploitable in practice: `dependency:tree` treats the local repo as a real repo and must resolve and **write** the maven-dependency-plugin artifacts into it, so a base the process cannot write to (`/`, another user's tree) fails the whole invocation before any fingerprinting runs, and a base it *can* write to is within the operator's own writable tree — not where sensitive read targets live. This is distinct from the primary vector above, which escapes a normal writable `.m2` on *read* and is therefore load-bearing.

#### What are the relevant tickets?

[CMPA-604](https://snyk.atlassian.net/browse/CMPA-604)

#### Screenshots

N/A

#### Additional questions

N/A

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Addresses verified security issues (arbitrary-file read oracle via dependency coordinates, credential leakage in distribution URLs); changes are defensive with graceful degradation for invalid inputs.
> 
> **Overview**
> Hardens two provenance/metadata paths against credential leaks and path traversal from untrusted Maven output.
> 
> **Repository URLs:** `stripUrlCredentials` now returns `undefined` when `new URL()` fails (e.g. invalid port), instead of returning the raw URL with embedded basic-auth. Sanitisation happens once in `fetchRepositoryUrlMap`’s `addRepo` before URLs enter the map or debug logs; unparseable repos are dropped. `buildDistributionUrlLabel` trusts pre-sanitised map URLs and no longer re-strips.
> 
> **Artifact paths:** `dependencyIdToArtifactPath` returns `string | undefined`, rejecting coordinates with unsafe segments (`..`, path separators) and paths that escape `repositoryPath` via a containment check. Fingerprinting skips filesystem access for rejected coordinates; `collectM2Nodes` omits those nodes so hash-label and distribution-url reads stay inside the repo.
> 
> Tests cover traversal/separator rejection, relocated repo bases, credential stripping at ingest, and dropping unparseable URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96248db724b6193bbcd56c50a80efb889ba46f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
