### PR TITLE
fix: scrub inline-credential repo URLs from mvn diagnostic output

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,6 +24,7 @@ import {
   buildRemoteRepositoryLabelMap,
 } from './parse/m2-remote-repositories';
 import { collectM2Nodes, buildLabelMap } from './parse/m2-batch';
+import { sanitiseCredentials } from './sanitise-output';
 import {
   SnykHttpClient,
   HashAlgorithm,
@@ -41,6 +42,17 @@ export function debug(...messages: string[]) {
     logger = debugModule('snyk-mvn-plugin');
   }
   messages.forEach((m) => logger?.(m));
+}
+
+/**
+ * `debug` for messages that may embed raw Maven output — i.e. anything that can
+ * carry an inline-credential repo URL (`Downloading from`/`Could not transfer`
+ * lines, dumped stdout/stderr). Each message is credential-scrubbed before it
+ * reaches the log sink. Use this instead of `debug` wherever untrusted
+ * subprocess output is logged; ordinary status messages can keep using `debug`.
+ */
+export function sanitisedDebug(...messages: string[]) {
+  debug(...messages.map(sanitiseCredentials));
 }
 
 export interface MavenOptions extends legacyPlugin.BaseInspectOptions {
@@ -254,7 +266,11 @@ export async function inspect(
     };
   } catch (err) {
     if (executionResult) {
-      debug(`>>> Output from mvn: ${executionResult.dependencyTreeResult}`);
+      // The raw tree output can include inline-credential `Downloading from`
+      // URLs — scrub before logging.
+      sanitisedDebug(
+        `>>> Output from mvn: ${executionResult.dependencyTreeResult}`,
+      );
     }
 
     // Handle Maven execution errors with proper command information

--- a/lib/maven/executor.ts
+++ b/lib/maven/executor.ts
@@ -7,7 +7,7 @@ import {
   VersionResolver,
   NO_OP_VERSION_RESOLVER,
 } from '../parse/version-resolver';
-import { debug } from '../index';
+import { debug, sanitisedDebug } from '../index';
 
 /**
  * Detect if Maven dependency tree output contains metaversions that require resolution
@@ -80,7 +80,9 @@ export async function executeMavenPipeline(
         args,
         explicitPluginVersion,
       );
-      debug(`Resolve result: ${resolveResult}`);
+      // resolveResult is raw mvn stdout, which can include inline-credential
+      // `Downloading from` URLs — scrub before logging.
+      sanitisedDebug(`Resolve result: ${resolveResult}`);
 
       // Parse immediately and fail fast if there's an issue
       versionResolver = createVersionResolver(resolveResult);

--- a/lib/sanitise-output.ts
+++ b/lib/sanitise-output.ts
@@ -1,0 +1,28 @@
+/**
+ * Redact credential-shaped spans from Maven diagnostic output before it is
+ * logged or folded into an error message. Maven itself holds the credentials
+ * (settings.xml `<server>` blocks, or — non-standard — inline repo/mirror URLs),
+ * so we can only scrub by *shape*, not by masking a known secret literal.
+ *
+ * Only the inline-`<url>` form (`https://user:token@host/…`) ever reaches
+ * Maven's output; `<server>` credentials are applied as HTTP auth and never
+ * printed. Maven emits the inline form on `Downloading from` / `Could not
+ * transfer` lines (stdout), on both successful and failed downloads, and
+ * aggregate builds can leave an earlier module's URLs in the partial output of
+ * a later module's failure — so any at-risk message is routed through here.
+ */
+export function sanitiseCredentials(text: string): string {
+  return (
+    text
+      // URL userinfo: `scheme://user:token@host/…` → `scheme://host/…`. Keep the
+      // host (which repo is useful for debugging); drop only the credential.
+      // `[^/\s]*@` consumes the whole authority-local userinfo up to its last
+      // `@` and cannot cross a `/`, so an `@` in a path is left alone.
+      .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s]*@/g, '$1')
+      // Auth headers Maven's HTTP wagon can echo under verbose/transport logging.
+      .replace(
+        /(Authorization:\s*(?:Basic|Bearer|Digest)\s+)\S+/gi,
+        '$1<redacted>',
+      )
+  );
+}

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,5 +1,5 @@
 import * as childProcess from 'child_process';
-import { debug, sanitisedDebug } from './index';
+import { debug } from './index';
 import { sanitiseCredentials } from './sanitise-output';
 import { escapeAll, quoteAll } from 'shescape/stateless';
 import * as os from 'node:os';
@@ -66,26 +66,25 @@ export function execute(command, args, options): Promise<string> {
     proc.on('close', (code) => {
       if (code !== 0) {
         // Maven's failure output can carry inline-credential repo URLs, so scrub
-        // before it reaches either sink: the log (via sanitisedDebug) and the
-        // rejected error message (via sanitiseCredentials — a thrown Error is not
-        // a debug line, so sanitisedDebug would not cover it).
-        sanitisedDebug(
+        // once here and reuse for both sinks — the debug log and the rejected
+        // error message (a thrown Error is not a debug line, so it needs the
+        // scrubbed value directly rather than going through sanitisedDebug).
+        const safeStderr = sanitiseCredentials(stderr);
+        const safeStdout = sanitiseCredentials(stdout);
+
+        debug(
           `Child process failed with exit code: ${code}`,
           '----------------',
           'STDERR:',
-          stderr,
+          safeStderr,
           '----------------',
           'STDOUT:',
-          stdout,
+          safeStdout,
           '----------------',
         );
 
-        const stdErrMessage = stderr
-          ? `\nSTDERR:\n${sanitiseCredentials(stderr)}`
-          : '';
-        const stdOutMessage = stdout
-          ? `\nSTDOUT:\n${sanitiseCredentials(stdout)}`
-          : '';
+        const stdErrMessage = safeStderr ? `\nSTDERR:\n${safeStderr}` : '';
+        const stdOutMessage = safeStdout ? `\nSTDOUT:\n${safeStdout}` : '';
         const debugSuggestion = process.env.DEBUG
           ? ''
           : `\nRun in debug mode (-d) to see STDERR and STDOUT.`;

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,37 +1,8 @@
 import * as childProcess from 'child_process';
-import { debug } from './index';
+import { debug, sanitisedDebug } from './index';
+import { sanitiseCredentials } from './sanitise-output';
 import { escapeAll, quoteAll } from 'shescape/stateless';
 import * as os from 'node:os';
-
-/**
- * Redact credential-shaped spans from a subprocess's diagnostic output before it
- * is logged or folded into an error message. Maven itself holds the credentials
- * (settings.xml `<server>` blocks, inline repo/mirror URLs), so — unlike a
- * builder that is handed the secret — we can only scrub by *shape*, not by
- * masking a known literal. This matters most for aggregate (multi-module)
- * builds: Maven walks every module, so a later module failing can leave an
- * earlier module's repository URLs (userinfo and all) in the partial STDOUT/
- * STDERR we then surface.
- *
- * Only failure diagnostics are passed through here; the success output is
- * returned verbatim because it is the real data we parse (and the repo-URL
- * path already strips credentials at ingest).
- */
-export function sanitiseSubprocessOutput(text: string): string {
-  return (
-    text
-      // URL userinfo: `scheme://user:token@host/…` → `scheme://host/…`. Keep the
-      // host (which repo failed is useful for debugging); drop only the
-      // credential. `[^/\s]*@` consumes the whole authority-local userinfo up to
-      // its last `@`, and cannot cross a `/`, so an `@` in a path is left alone.
-      .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s]*@/g, '$1')
-      // Auth headers Maven's HTTP wagon can echo under verbose/transport logging.
-      .replace(
-        /(Authorization:\s*(?:Basic|Bearer|Digest)\s+)\S+/gi,
-        '$1<redacted>',
-      )
-  );
-}
 
 export function execute(command, args, options): Promise<string> {
   const spawnOptions: {
@@ -94,24 +65,27 @@ export function execute(command, args, options): Promise<string> {
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        // Scrub credentials out of the diagnostic output before it reaches any
-        // log sink or error message (see sanitiseSubprocessOutput).
-        const safeStderr = sanitiseSubprocessOutput(stderr);
-        const safeStdout = sanitiseSubprocessOutput(stdout);
-
-        debug(
+        // Maven's failure output can carry inline-credential repo URLs, so scrub
+        // before it reaches either sink: the log (via sanitisedDebug) and the
+        // rejected error message (via sanitiseCredentials — a thrown Error is not
+        // a debug line, so sanitisedDebug would not cover it).
+        sanitisedDebug(
           `Child process failed with exit code: ${code}`,
           '----------------',
           'STDERR:',
-          safeStderr,
+          stderr,
           '----------------',
           'STDOUT:',
-          safeStdout,
+          stdout,
           '----------------',
         );
 
-        const stdErrMessage = safeStderr ? `\nSTDERR:\n${safeStderr}` : '';
-        const stdOutMessage = safeStdout ? `\nSTDOUT:\n${safeStdout}` : '';
+        const stdErrMessage = stderr
+          ? `\nSTDERR:\n${sanitiseCredentials(stderr)}`
+          : '';
+        const stdOutMessage = stdout
+          ? `\nSTDOUT:\n${sanitiseCredentials(stdout)}`
+          : '';
         const debugSuggestion = process.env.DEBUG
           ? ''
           : `\nRun in debug mode (-d) to see STDERR and STDOUT.`;

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -3,6 +3,36 @@ import { debug } from './index';
 import { escapeAll, quoteAll } from 'shescape/stateless';
 import * as os from 'node:os';
 
+/**
+ * Redact credential-shaped spans from a subprocess's diagnostic output before it
+ * is logged or folded into an error message. Maven itself holds the credentials
+ * (settings.xml `<server>` blocks, inline repo/mirror URLs), so — unlike a
+ * builder that is handed the secret — we can only scrub by *shape*, not by
+ * masking a known literal. This matters most for aggregate (multi-module)
+ * builds: Maven walks every module, so a later module failing can leave an
+ * earlier module's repository URLs (userinfo and all) in the partial STDOUT/
+ * STDERR we then surface.
+ *
+ * Only failure diagnostics are passed through here; the success output is
+ * returned verbatim because it is the real data we parse (and the repo-URL
+ * path already strips credentials at ingest).
+ */
+export function sanitiseSubprocessOutput(text: string): string {
+  return (
+    text
+      // URL userinfo: `scheme://user:token@host/…` → `scheme://host/…`. Keep the
+      // host (which repo failed is useful for debugging); drop only the
+      // credential. `[^/\s]*@` consumes the whole authority-local userinfo up to
+      // its last `@`, and cannot cross a `/`, so an `@` in a path is left alone.
+      .replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/\s]*@/g, '$1')
+      // Auth headers Maven's HTTP wagon can echo under verbose/transport logging.
+      .replace(
+        /(Authorization:\s*(?:Basic|Bearer|Digest)\s+)\S+/gi,
+        '$1<redacted>',
+      )
+  );
+}
+
 export function execute(command, args, options): Promise<string> {
   const spawnOptions: {
     shell: boolean;
@@ -64,19 +94,24 @@ export function execute(command, args, options): Promise<string> {
 
     proc.on('close', (code) => {
       if (code !== 0) {
+        // Scrub credentials out of the diagnostic output before it reaches any
+        // log sink or error message (see sanitiseSubprocessOutput).
+        const safeStderr = sanitiseSubprocessOutput(stderr);
+        const safeStdout = sanitiseSubprocessOutput(stdout);
+
         debug(
           `Child process failed with exit code: ${code}`,
           '----------------',
           'STDERR:',
-          stderr,
+          safeStderr,
           '----------------',
           'STDOUT:',
-          stdout,
+          safeStdout,
           '----------------',
         );
 
-        const stdErrMessage = stderr ? `\nSTDERR:\n${stderr}` : '';
-        const stdOutMessage = stdout ? `\nSTDOUT:\n${stdout}` : '';
+        const stdErrMessage = safeStderr ? `\nSTDERR:\n${safeStderr}` : '';
+        const stdOutMessage = safeStdout ? `\nSTDOUT:\n${safeStdout}` : '';
         const debugSuggestion = process.env.DEBUG
           ? ''
           : `\nRun in debug mode (-d) to see STDERR and STDOUT.`;

--- a/tests/jest/functional/sub-process.spec.ts
+++ b/tests/jest/functional/sub-process.spec.ts
@@ -1,9 +1,10 @@
-import { execute, sanitiseSubprocessOutput } from '../../../lib/sub-process';
+import { execute } from '../../../lib/sub-process';
+import { sanitiseCredentials } from '../../../lib/sanitise-output';
 
-describe('sanitiseSubprocessOutput', () => {
+describe('sanitiseCredentials', () => {
   it('strips userinfo from a repo URL but keeps the host and path', () => {
     expect(
-      sanitiseSubprocessOutput(
+      sanitiseCredentials(
         'Could not transfer artifact from https://user:s3cr3t@repo.internal/maven2/x.jar',
       ),
     ).toBe(
@@ -12,27 +13,27 @@ describe('sanitiseSubprocessOutput', () => {
   });
 
   it('strips user-only userinfo (no password)', () => {
-    expect(sanitiseSubprocessOutput('see https://deploy-token@host/p')).toBe(
+    expect(sanitiseCredentials('see https://deploy-token@host/p')).toBe(
       'see https://host/p',
     );
   });
 
   it('leaves a credential-free URL untouched', () => {
     const line = 'downloading from https://repo.maven.apache.org/maven2/';
-    expect(sanitiseSubprocessOutput(line)).toBe(line);
+    expect(sanitiseCredentials(line)).toBe(line);
   });
 
   it('does not treat an @ in a URL path as userinfo', () => {
     const line = 'https://repo.internal/maven2/group/a@b/1.0/a@b-1.0.jar';
-    expect(sanitiseSubprocessOutput(line)).toBe(line);
+    expect(sanitiseCredentials(line)).toBe(line);
   });
 
   it('redacts HTTP Authorization headers', () => {
     expect(
-      sanitiseSubprocessOutput('Authorization: Basic dXNlcjpwYXNzd29yZA=='),
+      sanitiseCredentials('Authorization: Basic dXNlcjpwYXNzd29yZA=='),
     ).toBe('Authorization: Basic <redacted>');
     expect(
-      sanitiseSubprocessOutput('authorization:  Bearer eyJhbGciOi.J9.sig'),
+      sanitiseCredentials('authorization:  Bearer eyJhbGciOi.J9.sig'),
     ).toBe('authorization:  Bearer <redacted>');
   });
 
@@ -45,14 +46,14 @@ describe('sanitiseSubprocessOutput', () => {
       '[INFO] Building moduleB',
       '[ERROR] Failed to read parent POM for moduleB',
     ].join('\n');
-    const out = sanitiseSubprocessOutput(partial);
+    const out = sanitiseCredentials(partial);
     expect(out).not.toContain('glpat-abcdef123456');
     expect(out).not.toContain('ci:');
     expect(out).toContain('https://nexus.corp/repo');
   });
 
   it('is a no-op for output with nothing to redact', () => {
-    expect(sanitiseSubprocessOutput('BUILD FAILURE\n')).toBe(
+    expect(sanitiseCredentials('BUILD FAILURE\n')).toBe(
       'BUILD FAILURE\n',
     );
   });

--- a/tests/jest/functional/sub-process.spec.ts
+++ b/tests/jest/functional/sub-process.spec.ts
@@ -1,0 +1,90 @@
+import { execute, sanitiseSubprocessOutput } from '../../../lib/sub-process';
+
+describe('sanitiseSubprocessOutput', () => {
+  it('strips userinfo from a repo URL but keeps the host and path', () => {
+    expect(
+      sanitiseSubprocessOutput(
+        'Could not transfer artifact from https://user:s3cr3t@repo.internal/maven2/x.jar',
+      ),
+    ).toBe(
+      'Could not transfer artifact from https://repo.internal/maven2/x.jar',
+    );
+  });
+
+  it('strips user-only userinfo (no password)', () => {
+    expect(sanitiseSubprocessOutput('see https://deploy-token@host/p')).toBe(
+      'see https://host/p',
+    );
+  });
+
+  it('leaves a credential-free URL untouched', () => {
+    const line = 'downloading from https://repo.maven.apache.org/maven2/';
+    expect(sanitiseSubprocessOutput(line)).toBe(line);
+  });
+
+  it('does not treat an @ in a URL path as userinfo', () => {
+    const line = 'https://repo.internal/maven2/group/a@b/1.0/a@b-1.0.jar';
+    expect(sanitiseSubprocessOutput(line)).toBe(line);
+  });
+
+  it('redacts HTTP Authorization headers', () => {
+    expect(
+      sanitiseSubprocessOutput('Authorization: Basic dXNlcjpwYXNzd29yZA=='),
+    ).toBe('Authorization: Basic <redacted>');
+    expect(
+      sanitiseSubprocessOutput('authorization:  Bearer eyJhbGciOi.J9.sig'),
+    ).toBe('authorization:  Bearer <redacted>');
+  });
+
+  it('scrubs an earlier module’s creds from partial aggregate-build output', () => {
+    // moduleA's repo (with inline creds) is printed before moduleB fails: the
+    // whole captured blob must be scrubbed, not just the failing line.
+    const partial = [
+      '[INFO] Building moduleA',
+      ' * internal (https://ci:glpat-abcdef123456@nexus.corp/repo, default, releases)',
+      '[INFO] Building moduleB',
+      '[ERROR] Failed to read parent POM for moduleB',
+    ].join('\n');
+    const out = sanitiseSubprocessOutput(partial);
+    expect(out).not.toContain('glpat-abcdef123456');
+    expect(out).not.toContain('ci:');
+    expect(out).toContain('https://nexus.corp/repo');
+  });
+
+  it('is a no-op for output with nothing to redact', () => {
+    expect(sanitiseSubprocessOutput('BUILD FAILURE\n')).toBe(
+      'BUILD FAILURE\n',
+    );
+  });
+});
+
+describe('execute() failure diagnostics', () => {
+  it('rejects with a message that carries the host but not the credentials', async () => {
+    // Spawn a real process that prints a credential-bearing URL and exits non-zero.
+    await expect(
+      execute(
+        process.execPath,
+        [
+          '-e',
+          'process.stderr.write("boom https://user:topsecret@repo.internal/x"); process.exit(3);',
+        ],
+        {},
+      ),
+    ).rejects.toThrow(/https:\/\/repo\.internal\/x/);
+
+    await expect(
+      execute(
+        process.execPath,
+        [
+          '-e',
+          'process.stderr.write("boom https://user:topsecret@repo.internal/x"); process.exit(3);',
+        ],
+        {},
+      ),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.not.stringContaining('topsecret'),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Stops Maven repository credentials from leaking into the plugin's debug logs and error messages.

**What actually leaks (verified on Maven 3.9.11):** when a repository is configured with **inline** userinfo in its `<url>` (`https://user:token@host/…`), Maven echoes it on **stdout** in `Downloading from` and `Could not transfer` lines — on both *successful* and *failed* downloads, from `dependency:tree` and `dependency:resolve` (not just `dependency:list-repositories`). Credentials configured the standard way — in a `settings.xml <server>` block — are applied as HTTP auth and **never** appear in output, so this is scoped to the non-standard inline-`<url>` form.

**Where it reached:** the only sinks are `debug` logs (so `-d`-only) — including *success-path* ones that dump raw mvn stdout: `executor.ts` `Resolve result: …` and `index.ts` `>>> Output from mvn: …` — plus the rejected error message built in `sub-process.ts`. User-facing thrown errors otherwise don't carry it (`dependency:tree` throws a static domain error; `resolve`/`list-repositories` are swallowed).

**The fix:**
- New `lib/sanitise-output.ts` `sanitiseCredentials(text)` — shape-based scrub (we never hold the secret): strips `scheme://user:token@host` userinfo while keeping host/path, and redacts `Authorization: Basic|Bearer|Digest` headers.
- New `sanitisedDebug(...)` wrapper in `index.ts` — `debug` that scrubs each message. The **at-risk** sinks are routed through it explicitly (rather than blanket-scrubbing every `debug` line): the `executor.ts` resolve-result log, the `index.ts` mvn-output log, and the `sub-process.ts` failure log.
- The rejected **error message** is scrubbed directly with `sanitiseCredentials` — a thrown `Error` isn't a debug line, so `sanitisedDebug` wouldn't cover it; downstream re-throw/swallow paths inherit the already-scrubbed message.

Success return values are left raw — that's the real data we parse, and repo URLs are already credential-stripped at ingest (`m2-remote-repositories.ts`, #229).

#### Where should the reviewer start?

`lib/sanitise-output.ts`, then the `sanitisedDebug` call sites (`sub-process.ts` failure branch, `executor.ts`, `index.ts`) and the `sanitiseCredentials`-wrapped reject message in `sub-process.ts`.

#### How should this be manually tested?

`npx jest tests/jest/functional/sub-process.spec.ts` — covers userinfo stripping (host/path preserved; `@` in a path left alone), `Authorization` redaction, the partial aggregate-build blob, and an end-to-end `execute()` failure asserting the rejection carries the host but not the credential. Full functional suite: 142 pass.

#### Any background context you want to provide?

Follow-up hardening from the CMPA-604 security thread (#229). Scope: recognises the shapes we can catch without holding the secret (inline-URL userinfo, auth headers); not a general secret-detector. Real-world exposure is low (standard `<server>` creds never print; leak is `-d`-only) — this is defense-in-depth. A separate non-security item — `execute()` appends STDERR/STDOUT to the error message even when `-d` is off, despite suggesting the user re-run with `-d` — is left alone here.

#### What are the relevant tickets?

[CMPA-604](https://snyk.atlassian.net/browse/CMPA-604)

#### Screenshots

N/A

#### Additional questions

N/A

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ