### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/open-source_composition-analysis
+* @snyk/engines_sca-scanners

--- a/tests/jest/system/dverbose-flag-all-versions.spec.ts
+++ b/tests/jest/system/dverbose-flag-all-versions.spec.ts
@@ -15,7 +15,7 @@ const testManagedProjectPath = path.join(
   'dverbose-dependency-management',
 );
 const complexProjectPath = path.join(fixturesPath, 'complex-aggregate-project');
-const TESTS_TIMEOUT = 50000;
+const TESTS_TIMEOUT = 180000;
 
 describe('Dverbose reuturning all considered versions for dependencies tests', () => {
   test(

--- a/tests/jest/system/dverbose-flag.spec.ts
+++ b/tests/jest/system/dverbose-flag.spec.ts
@@ -15,7 +15,7 @@ const testManagedProjectPath = path.join(
   'dverbose-dependency-management',
 );
 const complexProjectPath = path.join(fixturesPath, 'complex-aggregate-project');
-const TESTS_TIMEOUT = 50000;
+const TESTS_TIMEOUT = 180000;
 
 test(
   'inspect on dverbose-project pom using -Dverbose',


### PR DESCRIPTION
### What?

- `.github/CODEOWNERS`: ownership rules assigning `@snyk/open-source_composition-analysis` move to `@snyk/engines_sca-scanners` (other co-owners on shared lines are unchanged).

### Why?

`@snyk/engines_sca-scanners` now owns this repo, so review requests should land with them rather than the previous team.

---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update; no runtime or behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and test-timeout-only changes; no production or plugin behavior is modified.
> 
> **Overview**
> Transfers default GitHub review ownership from `@snyk/open-source_composition-analysis` to `@snyk/engines_sca-scanners` via the root `CODEOWNERS` rule.
> 
> Also raises `TESTS_TIMEOUT` from 50s to 180s in `dverbose-flag.spec.ts` and `dverbose-flag-all-versions.spec.ts` so slow Maven `-Dverbose` system tests are less likely to time out in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f0a17b0fdef087dc9b597f51dee6dadac9d69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->