### PR TITLE
chore: add prodsec-orb-runtime context to config.yaml [PRODSEC-10569]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
+            - prodsec-orb-runtime
           channel: snyk-vuln-alerts-sca
           filters:
             branches:
@@ -335,6 +336,7 @@ workflows:
           context:
             - open_source-managed
             - nodejs-install
+            - prodsec-orb-runtime
 
       - lint:
           name: Lint


### PR DESCRIPTION
## Summary
This PR adds the `prodsec-orb-runtime` context to jobs and workflows that use prodsec-orb commands.

## Changes
- Added `prodsec-orb-runtime` context to jobs using:
  - `prodsec/secrets-scan`
  - `prodsec/security_scans`
  - `prodsec/container_scan`
  - `publish/publish`

## Related
PRODSEC-10569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only context wiring for existing prodsec orb jobs; no application code, auth, or release logic changes in this diff.
> 
> **Overview**
> Adds the CircleCI context **`prodsec-orb-runtime`** to workflow jobs that invoke **`snyk/prodsec-orb`** so those steps receive the runtime secrets/config the orb expects.
> 
> The **`prodsec/secrets-scan`** job’s context list now includes **`prodsec-orb-runtime`** alongside **`snyk-bot-slack`**. The **`Security Scans`** job (local **`security-scans`** job using **`prodsec/security_scans`**) gets the same context in addition to **`open_source-managed`** and **`nodejs-install`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02ea315fdcc2f011c65f0e8f9a769989f3a6bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->