### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/open-source_composition-analysis
+* @snyk/engines_sca-scanners

--- a/tests/jest/system/dverbose-flag-all-versions.spec.ts
+++ b/tests/jest/system/dverbose-flag-all-versions.spec.ts
@@ -15,7 +15,7 @@ const testManagedProjectPath = path.join(
   'dverbose-dependency-management',
 );
 const complexProjectPath = path.join(fixturesPath, 'complex-aggregate-project');
-const TESTS_TIMEOUT = 50000;
+const TESTS_TIMEOUT = 180000;
 
 describe('Dverbose reuturning all considered versions for dependencies tests', () => {
   test(

--- a/tests/jest/system/dverbose-flag.spec.ts
+++ b/tests/jest/system/dverbose-flag.spec.ts
@@ -15,7 +15,7 @@ const testManagedProjectPath = path.join(
   'dverbose-dependency-management',
 );
 const complexProjectPath = path.join(fixturesPath, 'complex-aggregate-project');
-const TESTS_TIMEOUT = 50000;
+const TESTS_TIMEOUT = 180000;
 
 test(
   'inspect on dverbose-project pom using -Dverbose',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Re-opens #232 (CODEOWNERS ownership transfer to `@snyk/engines_sca-scanners`), plus a fix for the CI failure that was blocking it.

`test_and_release` on #232 failed only on `Windows Tests for Maven=3.6.3 JDK=17 Node=20.18.1`, in `tests/jest/system/dverbose-flag-all-versions.spec.ts`, on a `50000 ms` test timeout. That 50s figure is a per-test override hardcoded in `dverbose-flag.spec.ts` and `dverbose-flag-all-versions.spec.ts`, which overrides the `180000 ms` (`--testTimeout=180000`) the `test:system*` npm scripts otherwise apply to every other system test. These two tests spawn real Maven subprocesses, and Windows CI runners are slow enough that the 50s cap trips intermittently — unrelated to the CODEOWNERS change #232 was actually making.

This PR:
- Bumps the hardcoded `TESTS_TIMEOUT` in both spec files from `50000` to `180000` to match the CLI's `--testTimeout` value.
- Carries forward the one-line `.github/CODEOWNERS` change from #232.

#### Where should the reviewer start?

`tests/jest/system/dverbose-flag.spec.ts` and `tests/jest/system/dverbose-flag-all-versions.spec.ts` (the `TESTS_TIMEOUT` constant), and `.github/CODEOWNERS`.

#### How should this be manually tested?

`npm run test:system-maven3` (or `test:system-maven4`) locally passes; verified `dverbose-flag-all-versions.spec.ts` passes standalone with `--testTimeout=180000`.

#### Any background context you want to provide?

#232 was blocked purely by this flaky/undertimed test, not by the CODEOWNERS diff itself.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions



---
_Generated by [Claude Code](https://claude.ai/code/session_019cNef7Htjbeu4tZxokwGKU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CODEOWNERS and test timeout configuration; no production or plugin logic is modified.
> 
> **Overview**
> Transfers default repository ownership in `.github/CODEOWNERS` from `@snyk/open-source_composition-analysis` to `@snyk/engines_sca-scanners`.
> 
> Raises `TESTS_TIMEOUT` from `50000` to `180000` in `dverbose-flag.spec.ts` and `dverbose-flag-all-versions.spec.ts` so per-test limits match the `--testTimeout=180000` used by `test:system*` scripts, addressing intermittent Windows CI failures on Maven-heavy `-Dverbose` system tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ee8cf2116913e9ff45e389e648ce7248707325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->